### PR TITLE
Improve certificate hash display

### DIFF
--- a/app/src/main/java/sk/styk/martin/apkanalyzer/ui/appdetail/page/certificate/AppCertificateDetailsFragmentViewModel.kt
+++ b/app/src/main/java/sk/styk/martin/apkanalyzer/ui/appdetail/page/certificate/AppCertificateDetailsFragmentViewModel.kt
@@ -44,6 +44,11 @@ class AppCertificateDetailsFragmentViewModel @AssistedInject constructor(
                 TextInfo.from(R.string.cert_md5_description),
             ),
             DetailInfoAdapter.DetailInfo(
+                TextInfo.from(R.string.cert_sha1),
+                TextInfo.from(data.certificateHashSha1),
+                TextInfo.from(R.string.cert_sha1_description),
+            ),
+            DetailInfoAdapter.DetailInfo(
                 TextInfo.from(R.string.cert_sha256),
                 TextInfo.from(data.certificateHashSha256),
                 TextInfo.from(R.string.cert_sha256_description),

--- a/app/src/main/res/layout/list_item_detail.xml
+++ b/app/src/main/res/layout/list_item_detail.xml
@@ -40,7 +40,7 @@
             android:layout_weight="1"
             android:ellipsize="end"
             android:gravity="end"
-            android:maxLines="2"
+            android:maxLines="3"
             android:textAppearance="?android:attr/textAppearanceListItemSmall"
             app:text="@{viewModel.info.value}" />
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -126,6 +126,7 @@
     <string name="start_date">開始 : </string>
     <string name="end_date">有効期限  : </string>
     <string name="cert_md5">MD5証明書</string>
+    <string name="cert_sha1">SHA-1証明書</string>
     <string name="cert_sha256">SHA-256証明書</string>
     <string name="issuer_name">発行者名</string>
     <string name="issuer_organization">発行組織</string>
@@ -138,6 +139,7 @@
     <string name="start_date_description">証明書の有効期間の開始</string>
     <string name="end_date_description">証明書の有効期間の終了</string>
     <string name="cert_md5_description">証明書のMD5ハッシュ</string>
+    <string name="cert_sha1_description">証明書のSHA-1ハッシュ</string>
     <string name="cert_sha256_description">証明書のSHA-256ハッシュ</string>
     <string name="issuer_name_description">証明書の発行者の名前</string>
     <string name="issuer_organization_description">証明書の組織の名前</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -190,6 +190,7 @@
     <string name="start_date">有效日期</string>
     <string name="end_date">截止日期</string>
     <string name="cert_md5">MD5 憑證</string>
+    <string name="cert_sha1">SHA-1 憑證</string>
     <string name="cert_sha256">SHA-256 憑證</string>
     <string name="issuer_name">發行者名稱</string>
     <string name="issuer_organization">發行機構</string>
@@ -203,6 +204,7 @@
     <string name="start_date_description">憑證生效起始日期。</string>
     <string name="end_date_description">憑證效力截止日期。</string>
     <string name="cert_md5_description">憑證的 MD5 雜湊值。</string>
+    <string name="cert_sha1_description">憑證的 SHA-1 雜湊值。</string>
     <string name="cert_sha256_description">憑證的 SHA-256 雜湊值。</string>
     <string name="issuer_name_description">憑證發行者名稱。</string>
     <string name="issuer_organization_description">憑證發行機構名稱。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,6 +154,7 @@
     <string name="start_date">Valid from</string>
     <string name="end_date">Valid to</string>
     <string name="cert_md5">Certificate MD5</string>
+    <string name="cert_sha1">Certificate SHA-1</string>
     <string name="cert_sha256">Certificate SHA-256</string>
     <string name="issuer_name">Issuer name</string>
     <string name="issuer_organization">Issuer organization</string>
@@ -166,6 +167,7 @@
     <string name="start_date_description">Start of validity period of the certificate.</string>
     <string name="end_date_description">End of validity period of the certificate.</string>
     <string name="cert_md5_description">MD5 hash of the certificate.</string>
+    <string name="cert_sha1_description">SHA-1 hash of the certificate.</string>
     <string name="cert_sha256_description">SHA-256 hash of the certificate.</string>
     <string name="issuer_name_description">Name of issuer of the certificate</string>
     <string name="issuer_organization_description">Name of organization of issuer of the certificate</string>

--- a/core/app-analysis-core/src/main/java/sk/styk/martin/apkanalyzer/core/appanalysis/CertificateManager.kt
+++ b/core/app-analysis-core/src/main/java/sk/styk/martin/apkanalyzer/core/appanalysis/CertificateManager.kt
@@ -24,8 +24,10 @@ class CertificateManager @Inject internal constructor(private val digestManager:
             CertificateData(
                 signAlgorithm = certificate.sigAlgName,
                 certificateHashMd5 = digestManager.md5Digest(certificate.encoded),
+                certificateHashSha1 = digestManager.sha1Digest(certificate.encoded),
                 certificateHashSha256 = digestManager.sha256Digest(certificate.encoded),
                 publicKeyMd5 = digestManager.md5Digest(digestManager.byteToHexString(certificate.publicKey.encoded)),
+                publicKeySha1 = digestManager.sha1Digest(digestManager.byteToHexString(certificate.publicKey.encoded)),
                 publicKeySha256 = digestManager.sha256Digest(digestManager.byteToHexString(certificate.publicKey.encoded)),
                 startDate = certificate.notBefore,
                 endDate = certificate.notAfter,

--- a/core/app-analysis-core/src/main/java/sk/styk/martin/apkanalyzer/core/appanalysis/model/CertificateData.kt
+++ b/core/app-analysis-core/src/main/java/sk/styk/martin/apkanalyzer/core/appanalysis/model/CertificateData.kt
@@ -11,8 +11,10 @@ import java.util.Date
 data class CertificateData(
     val signAlgorithm: String,
     val certificateHashMd5: String,
+    val certificateHashSha1: String,
     val certificateHashSha256: String,
     val publicKeyMd5: String,
+    val publicKeySha1: String,
     val publicKeySha256: String,
     val startDate: Date,
     val endDate: Date,

--- a/core/common/src/main/java/sk/styk/martin/apkanalyzer/core/common/digest/DigestManager.kt
+++ b/core/common/src/main/java/sk/styk/martin/apkanalyzer/core/common/digest/DigestManager.kt
@@ -8,29 +8,13 @@ import javax.inject.Inject
 
 class DigestManager @Inject constructor() {
 
-    fun md5Digest(input: ByteArray): String {
-        val digest = getDigest("Md5")
-        digest.update(input)
-        return getHexString(digest.digest())
-    }
+    fun md5Digest(input: ByteArray): String = computeHash(algorithm = "Md5", input)
 
-    fun md5Digest(input: String): String {
-        val digest = getDigest("Md5")
-        digest.update(input.toByteArray())
-        return getHexString(digest.digest())
-    }
+    fun md5Digest(input: String): String = md5Digest(input.toByteArray())
 
-    fun sha256Digest(input: ByteArray): String {
-        val digest = getDigest("SHA-256")
-        digest.update(input)
-        return getHexString(digest.digest())
-    }
+    fun sha256Digest(input: ByteArray): String = computeHash(algorithm = "SHA-256", input)
 
-    fun sha256Digest(input: String): String {
-        val digest = getDigest("SHA-256")
-        digest.update(input.toByteArray())
-        return getHexString(digest.digest())
-    }
+    fun sha256Digest(input: String): String = sha256Digest(input.toByteArray())
 
     fun byteToHexString(bArray: ByteArray): String {
         val sb = StringBuilder(bArray.size)
@@ -60,5 +44,11 @@ class DigestManager @Inject constructor() {
         } catch (e: NoSuchAlgorithmException) {
             throw RuntimeException(e.message, e)
         }
+    }
+
+    private fun computeHash(algorithm: String, input: ByteArray): String {
+        val digest = getDigest(algorithm)
+        digest.update(input)
+        return getHexString(digest.digest())
     }
 }

--- a/core/common/src/main/java/sk/styk/martin/apkanalyzer/core/common/digest/DigestManager.kt
+++ b/core/common/src/main/java/sk/styk/martin/apkanalyzer/core/common/digest/DigestManager.kt
@@ -12,6 +12,10 @@ class DigestManager @Inject constructor() {
 
     fun md5Digest(input: String): String = md5Digest(input.toByteArray())
 
+    fun sha1Digest(input: ByteArray): String = computeHash(algorithm = "SHA-1", input)
+
+    fun sha1Digest(input: String): String = sha1Digest(input.toByteArray())
+
     fun sha256Digest(input: ByteArray): String = computeHash(algorithm = "SHA-256", input)
 
     fun sha256Digest(input: String): String = sha256Digest(input.toByteArray())


### PR DESCRIPTION
De-duplicate some logic, increase maximum lines for list items so longer values like the SHA-256 hash I added recently would fit and add SHA-1 certificate hash (I don't have a need for it but it's displayed in the same section of Play Console as MD-5 and SHA-256 hashes so it might be valuable to display).

I intentionally separated the changes to commits so you can decide to not include something if you don't agree with them but OFC you can squash them before merging if you want.