### PR TITLE
Fix build error about ExpandableLayout of libs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ mp-chart = "com.github.PhilJay:MPAndroidChart:v3.1.0-alpha"
 gif-drawable = "pl.droidsonroids.gif:android-gif-drawable:1.2.25"
 highlightjs = "com.pddstudio:highlightjs-android:1.5.0"
 appintro = "com.github.AppIntro:AppIntro:6.1.0"
-expandablelayout = "net.cachapa.expandablelayout:expandablelayout:2.9.2"
+expandablelayout = "com.github.cachapa:ExpandableLayout:2.9.2"
 timber = "com.jakewharton.timber:timber:5.0.1"
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }


### PR DESCRIPTION
After this, built successfully by command below:
```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew installFreeDebug
```

Environment:
```
Android Studio Otter 3 Feature Drop | 2025.2.3
Build #AI-252.28238.7.2523.14688667, built on January 9, 2026
Runtime version: 21.0.8+-14196175-b1038.72 x86_64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Toolkit: sun.lwawt.macosx.LWCToolkit
macOS 15.7.3
GC: G1 Young Generation, G1 Concurrent GC, G1 Old Generation
Memory: 2048M
Cores: 20
Metal Rendering is ON
Registry:
  ide.experimental.ui=true
```

