### PR TITLE
Use primary tint for app detail hub verdict icons

### DIFF
--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
@@ -594,7 +594,7 @@ private fun PermissionsSection(
         ) {
             Icon(
                 imageVector = if (highlightedSensitiveCount > 0) ApkAnalyzerIcons.DangerousPermissions else ApkAnalyzerIcons.Check,
-                tint = if (highlightedSensitiveCount > 0) AppTheme.colors.warning else AppTheme.colors.positive,
+                tint = if (highlightedSensitiveCount > 0) AppTheme.colors.warning else AppTheme.colors.primary,
                 modifier = Modifier.size(16.dp),
             )
             Spacer(modifier = Modifier.width(6.dp))
@@ -767,7 +767,7 @@ private fun RequirementsSection(
         ) {
             Icon(
                 imageVector = if (state.unmetRequirementsCount > 0) ApkAnalyzerIcons.Warning else ApkAnalyzerIcons.Check,
-                tint = if (state.unmetRequirementsCount > 0) AppTheme.colors.warning else AppTheme.colors.positive,
+                tint = if (state.unmetRequirementsCount > 0) AppTheme.colors.warning else AppTheme.colors.primary,
                 modifier = Modifier.size(16.dp),
             )
             Spacer(modifier = Modifier.width(6.dp))


### PR DESCRIPTION
## Summary
- The Permissions and Device requirements cards on the app detail hub showed a saturated green check icon when nothing needed attention, which read as an alert-style success signal out of step with the rest of the screen.
- Certificates already tints its `Verified` icon with the brand `primary` color for a valid signature, so both cards now reuse that instead of `positive`, keeping `warning` as the only saturated status color on the hub.

## Test plan
- [x] `./gradlew :feature:app-detail:impl:compileDebugKotlin`
- [x] `./gradlew spotlessApply` (no further changes)
- [x] Installed on device and visually confirmed the Device requirements card's checkmark now renders in the brand teal instead of green