### PR TITLE
Smooth bottom navigation on nested screens

### DIFF
--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/ApkAnalyzerApp.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/ApkAnalyzerApp.kt
@@ -1,12 +1,15 @@
 package sk.styk.martin.apkanalyzer.ui
 
 import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
@@ -34,33 +37,33 @@ internal fun ApkAnalyzerApp() {
         Navigator(navigationState)
     }
 
-    Scaffold(
-        bottomBar = {
+    Scaffold { paddings ->
+        Box(modifier = Modifier.fillMaxSize()) {
+            SharedTransitionLayout {
+                CompositionLocalProvider(LocalSharedTransitionScope provides this) {
+                    val entryProvider = entryProvider {
+                        appEntries(navigator)
+                        appDetailEntries(navigator)
+                        permissionEntries()
+                        statisticsEntries()
+                        settingsEntries(navigator)
+                    }
+                    NavDisplay(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(paddings),
+                        entries = navigationState.toEntries(entryProvider),
+                        onBack = navigator::goBack,
+                    )
+                }
+            }
             NavigationBar(
                 items = TOP_LEVEL_DESTINATIONS,
                 selectedKey = navigationState.currentTopLevelKey,
-                isVisible = true, // navigationState.currentKey in navigationState.topLevelKeys,
+                isVisible = navigationState.currentKey in navigationState.topLevelKeys,
                 onSelectKey = navigator::navigate,
+                modifier = Modifier.align(Alignment.BottomCenter),
             )
-        },
-    ) { paddings ->
-        SharedTransitionLayout {
-            CompositionLocalProvider(LocalSharedTransitionScope provides this) {
-                val entryProvider = entryProvider {
-                    appEntries(navigator)
-                    appDetailEntries(navigator)
-                    permissionEntries()
-                    statisticsEntries()
-                    settingsEntries(navigator)
-                }
-                NavDisplay(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(paddings),
-                    entries = navigationState.toEntries(entryProvider),
-                    onBack = navigator::goBack,
-                )
-            }
         }
     }
 }

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/NavigationBar.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/NavigationBar.kt
@@ -2,26 +2,33 @@ package sk.styk.martin.apkanalyzer.core.uilibrary.components
 
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.background
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.BottomAppBar
-import androidx.compose.material3.BottomAppBarDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import kotlinx.collections.immutable.ImmutableList
+import sk.styk.martin.apkanalyzer.core.uilibrary.animation.NAV_DURATION_STANDARD
+
+val navigationBarContentPadding: Dp = 80.dp
 
 @Stable
 data class NavigationBarItem(val navKey: NavKey, val selectedIcon: ImageVector, val unselectedIcon: ImageVector, @StringRes val title: Int)
@@ -34,11 +41,9 @@ fun NavigationBar(
     onSelectKey: (NavKey) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    BottomAppVarVisibility(
+    BottomAppBarVisibility(
         isVisible = isVisible,
-        modifier = modifier
-            .fillMaxWidth()
-            .background(BottomAppBarDefaults.containerColor),
+        modifier = modifier.fillMaxWidth(),
     ) {
         BottomAppBar {
             items.forEach { item ->
@@ -62,7 +67,7 @@ fun NavigationBar(
 }
 
 @Composable
-private fun BottomAppVarVisibility(
+private fun BottomAppBarVisibility(
     isVisible: Boolean,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
@@ -70,26 +75,42 @@ private fun BottomAppVarVisibility(
     AnimatedVisibility(
         visible = isVisible,
         modifier = modifier,
-        enter = expandVertically(
+        enter = slideInVertically(
             animationSpec = tween(
-                durationMillis = 200,
-                delayMillis = 100,
+                durationMillis = NAV_DURATION_STANDARD,
+                easing = LinearOutSlowInEasing,
             ),
+            initialOffsetY = { it },
+        ) + scaleIn(
+            animationSpec = tween(
+                durationMillis = NAV_DURATION_STANDARD,
+                easing = LinearOutSlowInEasing,
+            ),
+            initialScale = 0.96f,
+            transformOrigin = TransformOrigin(0.5f, 1f),
         ) + fadeIn(
             animationSpec = tween(
-                durationMillis = 200,
+                durationMillis = 180,
                 delayMillis = 100,
             ),
         ),
-        exit = shrinkVertically(
+        exit = slideOutVertically(
             animationSpec = tween(
-                durationMillis = 200,
-                delayMillis = 100,
+                durationMillis = 300,
+                easing = FastOutLinearInEasing,
             ),
+            targetOffsetY = { it },
+        ) + scaleOut(
+            animationSpec = tween(
+                durationMillis = 300,
+                easing = FastOutLinearInEasing,
+            ),
+            targetScale = 0.96f,
+            transformOrigin = TransformOrigin(0.5f, 1f),
         ) + fadeOut(
             animationSpec = tween(
-                durationMillis = 200,
-                delayMillis = 100,
+                durationMillis = 100,
+                delayMillis = 200,
             ),
         ),
     ) {

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsScreen.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsScreen.kt
@@ -50,6 +50,7 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.components.IconButton
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.IconButtonStyle
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.InactiveSearchBar
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.Text
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.navigationBarContentPadding
 import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
 import sk.styk.martin.apkanalyzer.core.uilibrary.lazylist.itemsPositioned
 import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.card
@@ -169,7 +170,11 @@ private fun AppsContent(
 
         LazyColumn(
             state = lazyListState,
-            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 16.dp),
+            contentPadding = PaddingValues(
+                start = 16.dp,
+                end = 16.dp,
+                bottom = navigationBarContentPadding + 16.dp,
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .offset { collapsingState.contentOffset },


### PR DESCRIPTION
Nested destinations should hide bottom navigation without resizing the navigation host during screen transitions. The previous Scaffold bottom-bar approach changed content bounds while the bar animated, which made nested navigation feel unstable.

## Summary
- Render bottom navigation as an overlay so `NavDisplay` keeps stable bounds.
- Show the bar only when the current destination is one of the three top-level destinations.
- Move the complete painted bar beyond the screen edge with subtle scale and fade motion.
- Reserve bottom scroll space in the Apps list so content remains accessible beneath the overlay.

## Validation
- Built, installed, and exercised the transition on a connected Samsung device.