### PR TITLE
Remove signing certificate info icons

### DIFF
--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/certificates/CertificatesScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/certificates/CertificatesScreen.kt
@@ -531,16 +531,6 @@ private fun InfoFact(
                 color = AppTheme.colors.onSurface,
             )
         }
-        if (rationale != null && onShowRationale != null) {
-            Icon(
-                imageVector = ApkAnalyzerIcons.Info,
-                contentDescription = null,
-                tint = AppTheme.colors.onSurfaceVariant,
-                modifier = Modifier
-                    .padding(12.dp)
-                    .size(18.dp),
-            )
-        }
     }
 }
 


### PR DESCRIPTION
Certificate detail rows showed standalone info icons that are not used by other explanatory rows, making the shared interaction look inconsistent.

Remove those glyphs while preserving tap-to-explain and long-press-to-copy behavior.