### PR TITLE
Complete Spotless coverage

### DIFF
--- a/build-logic/AGENTS.md
+++ b/build-logic/AGENTS.md
@@ -20,7 +20,7 @@ Gradle convention plugins that standardize build configuration across all module
 
 ## Utility Files (`utils/`)
 
-- `AndroidSdk.kt` - `CompileSdk = 37`, `TargetSdk = 37`, `MinSdk = 28`
+- `AndroidSdk.kt` - `COMPILE_SDK = 37`, `TARGET_SDK = 37`, `MIN_SDK = 28`
 - `DependenciesExtension.kt` - `implementation()`, `api()` helper extensions
 - `Kotlin.kt` - `configureKotlin()` (JVM toolchain 25)
 - `ProjectExtensions.kt` - `Project.libs` accessor for version catalog
@@ -30,6 +30,9 @@ Gradle convention plugins that standardize build configuration across all module
 - Multiline function signatures at 3+ parameters
 - Compose naming rules (ignores `@Composable` for function naming)
 - `compositionlocal-allowlist` and `lambda-param-in-effect` rules disabled
+- Module applications format their Kotlin and Kotlin Gradle sources.
+- The root application formats root Gradle scripts, `build-logic`, YAML workflows, and `.gitignore` files.
+- Project-relative targets keep root and module formatting scopes from overlapping.
 
 ## When Adding a New Plugin
 1. Create implementation class in `src/main/kotlin/sk/styk/martin/apkanalyzer/`

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/ApplicationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/ApplicationPlugin.kt
@@ -5,9 +5,9 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
-import sk.styk.martin.apkanalyzer.utils.CompileSdk
-import sk.styk.martin.apkanalyzer.utils.MinSdk
-import sk.styk.martin.apkanalyzer.utils.TargetSdk
+import sk.styk.martin.apkanalyzer.utils.COMPILE_SDK
+import sk.styk.martin.apkanalyzer.utils.MIN_SDK
+import sk.styk.martin.apkanalyzer.utils.TARGET_SDK
 import sk.styk.martin.apkanalyzer.utils.configureKotlin
 import sk.styk.martin.apkanalyzer.utils.implementation
 import sk.styk.martin.apkanalyzer.utils.libs
@@ -22,10 +22,10 @@ class ApplicationPlugin : Plugin<Project> {
         }
 
         extensions.configure<ApplicationExtension> {
-            compileSdk = CompileSdk
+            compileSdk = COMPILE_SDK
             defaultConfig {
-                targetSdk = TargetSdk
-                minSdk = MinSdk
+                targetSdk = TARGET_SDK
+                minSdk = MIN_SDK
             }
 
             signingConfigs {

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/FeatureImplPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/FeatureImplPlugin.kt
@@ -17,6 +17,5 @@ class FeatureImplPlugin : Plugin<Project> {
             implementation(project(":core:ui-library"))
             implementation(project(":core:navigation"))
         }
-
     }
 }

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/LibraryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/LibraryPlugin.kt
@@ -4,8 +4,8 @@ import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
-import sk.styk.martin.apkanalyzer.utils.CompileSdk
-import sk.styk.martin.apkanalyzer.utils.MinSdk
+import sk.styk.martin.apkanalyzer.utils.COMPILE_SDK
+import sk.styk.martin.apkanalyzer.utils.MIN_SDK
 import sk.styk.martin.apkanalyzer.utils.configureKotlin
 
 class LibraryPlugin : Plugin<Project> {
@@ -16,9 +16,9 @@ class LibraryPlugin : Plugin<Project> {
         }
 
         extensions.configure<LibraryExtension> {
-            compileSdk = CompileSdk
+            compileSdk = COMPILE_SDK
             defaultConfig {
-                minSdk = MinSdk
+                minSdk = MIN_SDK
             }
         }
 

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/SpotlessPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/SpotlessPlugin.kt
@@ -17,9 +17,10 @@ class SpotlessPlugin : Plugin<Project> {
 
         extensions.configure<SpotlessExtension> {
             kotlin {
-                target("**/*.kt")
-                targetExclude("${layout.buildDirectory}/**/*.kt")
-                targetExclude("bin/**/*.kt")
+                target(
+                    "src/**/*.kt",
+                    "build-logic/convention/src/**/*.kt",
+                )
                 ktlint()
                     .customRuleSets(listOf(composeRulesKtlint))
                     .editorConfigOverride(
@@ -29,14 +30,27 @@ class SpotlessPlugin : Plugin<Project> {
                             "ktlint_compose_compositionlocal-allowlist" to "disabled",
                             "ktlint_compose_lambda-param-in-effect" to "disabled",
                             "ktlint_function_naming_ignore_when_annotated_with" to "Composable",
-                        )
+                        ),
                     )
             }
             kotlinGradle {
-                target("**/*.kt")
-                target("**/*.kts")
-                targetExclude("${layout.buildDirectory}/**/*.kts")
+                target(
+                    "*.gradle.kts",
+                    "settings.gradle.kts",
+                    "build-logic/*.gradle.kts",
+                    "build-logic/**/*.gradle.kts",
+                )
                 ktlint()
+            }
+            format("misc") {
+                target(
+                    ".github/**/*.yml",
+                    ".github/**/*.yaml",
+                    ".gitignore",
+                    ".idea/.gitignore",
+                )
+                trimTrailingWhitespace()
+                endWithNewline()
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/ValidateAgentContextTask.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/ValidateAgentContextTask.kt
@@ -46,6 +46,7 @@ abstract class ValidateAgentContextTask : DefaultTask() {
             val claudeFile = agentFile.resolveSibling("CLAUDE.md")
             when {
                 !claudeFile.isFile -> errors += "Missing ${claudeFile.displayPath()} for ${agentFile.displayPath()}."
+
                 claudeFile.readText().trim() != "@AGENTS.md" ->
                     errors += "${claudeFile.displayPath()} must contain only @AGENTS.md."
             }
@@ -160,7 +161,7 @@ abstract class ValidateAgentContextTask : DefaultTask() {
                 claudeFiles +
                 skillFiles +
                 listOf(rootDirectory.resolve("README.md"), copilotInstructions)
-        ).filter(File::isFile)
+            ).filter(File::isFile)
             .distinct()
         val markdownLinkPattern = Regex("""(?<!!)\[[^]]+]\(([^)]+)\)""")
 

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/utils/AndroidSdk.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/utils/AndroidSdk.kt
@@ -1,5 +1,5 @@
 package sk.styk.martin.apkanalyzer.utils
 
-const val CompileSdk = 37
-const val TargetSdk = 37
-const val MinSdk = 28
+const val COMPILE_SDK = 37
+const val TARGET_SDK = 37
+const val MIN_SDK = 28

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/utils/DependenciesExtension.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/utils/DependenciesExtension.kt
@@ -5,17 +5,12 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.provider.Provider
 
-internal fun DependencyHandler.implementation(dependencyNotation: Any): Dependency? =
-    add("implementation", dependencyNotation)
+internal fun DependencyHandler.implementation(dependencyNotation: Any): Dependency? = add("implementation", dependencyNotation)
 
-internal fun DependencyHandler.implementation(dependencyNotation: Provider<*>, configuration: Action<*>) =
-    addProvider("implementation", dependencyNotation, configuration)
+internal fun DependencyHandler.implementation(dependencyNotation: Provider<*>, configuration: Action<*>) = addProvider("implementation", dependencyNotation, configuration)
 
-internal fun DependencyHandler.api(dependencyNotation: Any): Dependency? =
-    add("api", dependencyNotation)
+internal fun DependencyHandler.api(dependencyNotation: Any): Dependency? = add("api", dependencyNotation)
 
-internal fun DependencyHandler.api(dependencyNotation: Provider<*>, configuration: Action<*>) =
-    addProvider("api", dependencyNotation, configuration)
+internal fun DependencyHandler.api(dependencyNotation: Provider<*>, configuration: Action<*>) = addProvider("api", dependencyNotation, configuration)
 
-internal fun DependencyHandler.ksp(dependencyNotation: Any): Dependency? =
-    add("ksp", dependencyNotation)
+internal fun DependencyHandler.ksp(dependencyNotation: Any): Dependency? = add("ksp", dependencyNotation)

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/utils/Kotlin.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/utils/Kotlin.kt
@@ -5,7 +5,6 @@ import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-
 internal fun Project.configureKotlin() {
     extensions.configure(KotlinAndroidProjectExtension::class.java) {
         jvmToolchain(25)
@@ -18,6 +17,5 @@ internal fun Project.configureKotlin() {
                 "-opt-in=kotlinx.coroutines.FlowPreview",
             )
         }
-
     }
 }

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/utils/ProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/utils/ProjectExtensions.kt
@@ -12,7 +12,6 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.getByType
 
-
 val Project.androidLibrary: LibraryExtension
     get() = extensions.getByType(LibraryExtension::class.java)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.apkanalyzer.agent.context)
+    alias(libs.plugins.apkanalyzer.spotless)
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.compose.compiler) apply false

--- a/docs/technical/kotlin-code-quality.md
+++ b/docs/technical/kotlin-code-quality.md
@@ -26,10 +26,9 @@ Each tool should have one responsibility:
 
 Detekt formatting rules should remain disabled so they do not overlap or disagree with Spotless.
 
-ktlint should be pinned explicitly to the newest compatible release. Pinning does not mean staying
-on an old release: it makes the selected version visible, lets ktlint be upgraded independently of
-Spotless, and prevents a Spotless upgrade from silently changing formatting behavior. The version
-should be updated deliberately whenever a newer compatible ktlint release is available.
+The repository should use the ktlint version selected by Spotless and update Spotless deliberately.
+An explicit ktlint override adds another compatibility decision without providing value while the
+Spotless default is current and compatible with compose-rules-ktlint.
 
 The repository should keep the `intellij_idea` ktlint style. `ktlint_official` would standardize
 some wrapping and indentation decisions, but it would not make Kotlin more idiomatic or add semantic
@@ -53,7 +52,7 @@ The following snapshot was taken on 2026-08-08.
 ### Gaps
 
 - Spotless does not cover root Gradle scripts or `build-logic` sources.
-- The ktlint version is implicit in the Spotless version instead of being pinned independently.
+- Kotlin files are targeted by both the Kotlin and Kotlin Gradle Spotless steps.
 - `.editorconfig` selects `intellij_idea` style and allows lines up to 240 characters.
 - There is no Detekt configuration.
 - Kotlin compiler warnings are not treated as errors.
@@ -92,22 +91,25 @@ Examples currently outside automated enforcement include:
 Each step is intended to be a separate pull request. Mechanical formatting changes must not be
 combined with Detekt-driven refactoring.
 
-### KQ-01: Make formatting deterministic and complete
+### KQ-01: Make formatting complete and consistently managed
 
 **Changes**
 
-- Add the newest compatible ktlint version explicitly to `gradle/libs.versions.toml`.
-- Pass that version to both Kotlin and Kotlin Gradle Spotless steps.
-- Update ktlint independently when newer compatible releases become available.
-- Apply Spotless to root Gradle scripts and `build-logic`.
-- Add a lightweight miscellaneous format for trailing whitespace and final newlines in Markdown,
-  YAML, properties files, and `.gitignore`.
+- Update Spotless to the newest compatible release and use its managed ktlint version.
+- Apply the existing Spotless convention plugin to the root project.
+- Make the convention plugin format root Gradle scripts and `build-logic` when applied at the root.
+- Use project-relative targets that do not overlap between root and module applications.
+- Stop targeting Kotlin files from the Kotlin Gradle step.
+- Add a lightweight miscellaneous format for trailing whitespace and final newlines in YAML and
+  `.gitignore` files. Leave Markdown and properties files unchanged because trailing whitespace can
+  carry meaning in those formats.
 - Keep the existing formatting style in this step to avoid unrelated source changes.
 
 **Exit criteria**
 
 - `spotlessCheck` covers Android modules, root scripts, and `build-logic`.
-- Spotless and ktlint versions can be upgraded independently.
+- Spotless configuration remains centralized in the convention plugin.
+- Each Kotlin file is handled by one Spotless format.
 - `spotlessApply` leaves the working tree clean after a second run.
 
 ### KQ-02: Enforce a practical line-length limit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ google-services = "4.5.0"
 timber = "5.0.1"
 leakcanary = "2.14"
 coil = "3.5.0"
-spotless = "8.8.0"
+spotless = "8.9.0"
 compose-rules-ktlint = "0.6.3"
 
 [libraries]


### PR DESCRIPTION
Spotless previously formatted Android module sources but left root Gradle scripts and build logic unchecked. This makes formatting enforcement incomplete and allows build infrastructure to drift from the repository's Kotlin style.

## Changes

- Update Spotless to 8.9.0 and continue using its managed ktlint version.
- Apply the existing convention plugin at the repository root.
- Use explicit project-relative targets so root and module formatting scopes do not overlap.
- Cover root Gradle scripts, build logic, workflows, and project `.gitignore` files.
- Remove duplicate Kotlin targeting from the Kotlin Gradle format.
- Format existing build-logic violations, including standard Kotlin constant naming for SDK values.
- Update the technical plan and build-logic guidance to reflect the implemented approach.

## Verification

- `./gradlew spotlessApply spotlessCheck validateAgentContext`
- `./gradlew spotlessCheck validateAgentContext lintDebug :app:assembleDebug`