### PR TITLE
Add baseline-free Detekt analysis

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Spotless check
         run: ./gradlew spotlessCheck
 
+      - name: Detekt check
+        run: ./gradlew detektDebug :build-logic:convention:detektMain
+
       - name: Lint check
         run: ./gradlew lintDebug
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ re-deriving the module's structure.
 |---|---|
 | Iterating on one module | `./gradlew :feature:apps:impl:compileDebugKotlin` |
 | Before committing | `./gradlew spotlessApply` |
-| Whole-app check (what CI gates on) | `./gradlew spotlessCheck lintDebug :app:assembleDebug` |
+| Whole-app check (what CI gates on) | `./gradlew spotlessCheck detektDebug :build-logic:convention:detektMain lintDebug :app:assembleDebug` |
 | After changing a context file, skill, adapter, or the module graph | `./gradlew validateAgentContext` |
 
 A successful compile is not proof a Compose layout is correct. For visual or layout changes, use

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ApkAnalyzer.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ApkAnalyzer.kt
@@ -2,6 +2,7 @@ package sk.styk.martin.apkanalyzer
 
 import android.app.Application
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.ProcessLifecycleOwner
 import coil3.ImageLoader
@@ -23,7 +24,7 @@ class ApkAnalyzer :
 
     override fun onCreate() {
         super.onCreate()
-        Logger.init(logToConsole = BuildConfig.DEBUG)
+        Logger.init(logToConsole = applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0)
         lifecycleObservers.forEach { ProcessLifecycleOwner.get().lifecycle.addObserver(it) }
     }
 

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ApkAnalyzer.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ApkAnalyzer.kt
@@ -2,7 +2,6 @@ package sk.styk.martin.apkanalyzer
 
 import android.app.Application
 import android.content.Context
-import android.content.pm.ApplicationInfo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.ProcessLifecycleOwner
 import coil3.ImageLoader
@@ -24,7 +23,7 @@ class ApkAnalyzer :
 
     override fun onCreate() {
         super.onCreate()
-        Logger.init(logToConsole = applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0)
+        Logger.init(logToConsole = BuildConfig.DEBUG)
         lifecycleObservers.forEach { ProcessLifecycleOwner.get().lifecycle.addObserver(it) }
     }
 

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/externalapk/ExternalApkActivity.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/externalapk/ExternalApkActivity.kt
@@ -42,7 +42,8 @@ class ExternalApkActivity : ComponentActivity() {
 @Suppress("DEPRECATION")
 private fun Intent.externalApkUri(): String? {
     if (action != Intent.ACTION_VIEW && action != Intent.ACTION_INSTALL_PACKAGE) return null
-    return data
-        ?.takeIf { it.scheme == ContentResolver.SCHEME_CONTENT || it.scheme == ContentResolver.SCHEME_FILE }
+    val uri = data ?: return null
+    return uri
+        .takeIf { it.scheme == ContentResolver.SCHEME_CONTENT || it.scheme == ContentResolver.SCHEME_FILE }
         ?.toString()
 }

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/util/file/GenericFileProvider.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/util/file/GenericFileProvider.kt
@@ -4,6 +4,6 @@ import androidx.core.content.FileProvider
 
 class GenericFileProvider : FileProvider() {
     companion object {
-        val AUTHORITY = "sk.styk.martin.apkanalyzer"
+        const val AUTHORITY = "sk.styk.martin.apkanalyzer"
     }
 }

--- a/build-logic/AGENTS.md
+++ b/build-logic/AGENTS.md
@@ -17,6 +17,7 @@ Gradle convention plugins that standardize build configuration across all module
 | `apkanalyzer.hilt` | `HiltPlugin.kt` | `hilt.android` + `ksp` + hilt-compiler |
 | `apkanalyzer.compose` | `ComposePlugin.kt` | `kotlin.compose` + `kotlin.serialization` + Compose BOM + compose bundle + navigation3 bundle |
 | `apkanalyzer.spotless` | `SpotlessPlugin.kt` | Spotless + ktlint + compose-rules-ktlint custom ruleset |
+| `apkanalyzer.detekt` | `DetektPlugin.kt` | Baseline-free, type-resolved Kotlin static analysis using the shared root configuration |
 
 ## Utility Files (`utils/`)
 
@@ -30,6 +31,12 @@ Gradle convention plugins that standardize build configuration across all module
 - Multiline function signatures at 3+ parameters
 - Compose naming rules (ignores `@Composable` for function naming)
 - `compositionlocal-allowlist` and `lambda-param-in-effect` rules disabled
+
+## Detekt Configuration
+- Shared rules in `config/detekt/detekt.yml`
+- Android modules analyze the debug variant with type resolution
+- `build-logic` analyzes its main JVM source set
+- CI runs every Android module's `detektDebug` task and `build-logic:convention:detektMain`
 
 ## When Adding a New Plugin
 1. Create implementation class in `src/main/kotlin/sk/styk/martin/apkanalyzer/`

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `kotlin-dsl`
+    alias(libs.plugins.detekt)
 }
 
 group = "sk.styk.martin.apkanalyzer.buildlogic"
@@ -13,6 +14,14 @@ dependencies {
     compileOnly(libs.kotlin.gradle.plugin)
     compileOnly(libs.ksp.gradle.plugin)
     compileOnly(libs.spotless.gradle.plugin)
+    compileOnly(libs.detekt.gradle.plugin)
+}
+
+detekt {
+    buildUponDefaultConfig.set(true)
+    config.setFrom(layout.projectDirectory.file("../../config/detekt/detekt.yml"))
+    basePath.set(layout.projectDirectory.dir("../.."))
+    parallel.set(true)
 }
 
 gradlePlugin {
@@ -44,6 +53,10 @@ gradlePlugin {
         register("apkanalyzer.spotless") {
             id = "apkanalyzer.spotless"
             implementationClass = "sk.styk.martin.apkanalyzer.SpotlessPlugin"
+        }
+        register("apkanalyzer.detekt") {
+            id = "apkanalyzer.detekt"
+            implementationClass = "sk.styk.martin.apkanalyzer.DetektPlugin"
         }
         register("apkanalyzer.compose") {
             id = "apkanalyzer.compose"

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/ApplicationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/ApplicationPlugin.kt
@@ -19,6 +19,7 @@ class ApplicationPlugin : Plugin<Project> {
             apply("com.google.gms.google-services")
             apply("com.google.firebase.firebase-perf")
             apply("com.google.firebase.crashlytics")
+            apply("apkanalyzer.detekt")
         }
 
         extensions.configure<ApplicationExtension> {

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/DetektPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/DetektPlugin.kt
@@ -1,0 +1,21 @@
+package sk.styk.martin.apkanalyzer
+
+import dev.detekt.gradle.extensions.DetektExtension
+import dev.detekt.gradle.extensions.FailOnSeverity
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class DetektPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("dev.detekt")
+
+        extensions.configure<DetektExtension> {
+            buildUponDefaultConfig.set(true)
+            config.setFrom(rootProject.layout.projectDirectory.file("config/detekt/detekt.yml"))
+            basePath.set(rootProject.layout.projectDirectory)
+            parallel.set(true)
+            failOnSeverity.set(FailOnSeverity.Error)
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/LibraryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/LibraryPlugin.kt
@@ -13,6 +13,7 @@ class LibraryPlugin : Plugin<Project> {
         with(pluginManager) {
             apply("com.android.library")
             apply("apkanalyzer.spotless")
+            apply("apkanalyzer.detekt")
         }
 
         extensions.configure<LibraryExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,4 +10,5 @@ plugins {
     alias(libs.plugins.crashlytics) apply false
     alias(libs.plugins.firebase.perf) apply false
     alias(libs.plugins.spotless) apply false
+    alias(libs.plugins.detekt) apply false
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,84 @@
+config:
+  validation: true
+  warningsAsErrors: true
+
+comments:
+  active: false
+
+complexity:
+  severity: warning
+  CyclomaticComplexMethod:
+    allowedComplexity: 15
+  TooManyFunctions:
+    active: false
+
+coroutines:
+  GlobalCoroutineUsage:
+    active: true
+  InjectDispatcher:
+    excludes:
+      - '**/coroutines/DispatcherProvider.kt'
+  SuspendFunInFinallySection:
+    active: true
+  SuspendFunSwallowedCancellation:
+    active: true
+
+exceptions:
+  TooGenericExceptionCaught:
+    severity: warning
+  TooGenericExceptionThrown:
+    severity: warning
+  ErrorUsageWithThrowable:
+    active: true
+  NotImplementedDeclaration:
+    active: true
+  ObjectExtendsThrowable:
+    active: true
+
+potential-bugs:
+  CastNullableToNonNullableType:
+    active: true
+  CastToNullableType:
+    active: true
+  CharArrayToStringCall:
+    active: true
+  DontDowncastCollectionTypes:
+    active: true
+  NullCheckOnMutableProperty:
+    active: true
+  NullableToStringCall:
+    active: true
+  PropertyUsedBeforeDeclaration:
+    active: true
+  UnconditionalJumpStatementInLoop:
+    active: true
+
+style:
+  LoopWithTooManyJumpStatements:
+    severity: warning
+  MagicNumber:
+    active: false
+  MaxLineLength:
+    active: false
+  ModifierOrder:
+    active: false
+  NewLineAtEndOfFile:
+    active: false
+  ReturnCount:
+    severity: warning
+  ThrowsCount:
+    severity: warning
+  UnusedPrivateFunction:
+    allowedNames: '.*Preview'
+  UnusedPrivateProperty:
+    active: false
+  WildcardImport:
+    active: false
+
+naming:
+  FunctionNaming:
+    active: false
+  MatchingDeclarationName:
+    active: false
+  TopLevelPropertyNaming:
+    constantPattern: '[A-Z][A-Za-z0-9_]*'

--- a/core/apk-files/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apkfiles/TemporaryApkManagerImpl.kt
+++ b/core/apk-files/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apkfiles/TemporaryApkManagerImpl.kt
@@ -4,7 +4,6 @@ import android.app.ActivityManager
 import android.content.Context
 import android.net.Uri
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -27,15 +26,17 @@ internal class TemporaryApkManagerImpl @Inject constructor(
 
     override suspend fun copy(uri: Uri, taskId: Int): Result<File> {
         var copiedFile: File? = null
+        var copyCompleted = false
         return try {
             withContext(dispatcherProvider.io()) {
                 copyToTaskDirectory(uri, taskId).also { result ->
                     copiedFile = result.getOrNull()
                 }
+            }.also {
+                copyCompleted = true
             }
-        } catch (error: CancellationException) {
-            copiedFile?.let(::releaseAfterCopyFailure)
-            throw error
+        } finally {
+            if (!copyCompleted) copiedFile?.let(::releaseAfterCopyFailure)
         }
     }
 
@@ -50,6 +51,7 @@ internal class TemporaryApkManagerImpl @Inject constructor(
 
     private suspend fun copyToTaskDirectory(uri: Uri, taskId: Int): Result<File> {
         var destination: File? = null
+        var copyCompleted = false
         return try {
             cleanupDiscardedTasks()
             cleanupLegacyFiles()
@@ -65,19 +67,17 @@ internal class TemporaryApkManagerImpl @Inject constructor(
                     it.copyTo(output, MAX_APK_SIZE_BYTES)
                 }
             }
-            Result.success(destination)
-        } catch (error: CancellationException) {
-            destination?.let(::releaseAfterCopyFailure)
-            throw error
+            Result.success(destination).also {
+                copyCompleted = true
+            }
         } catch (error: IOException) {
-            destination?.let(::releaseAfterCopyFailure)
             Result.failure(error)
         } catch (error: SecurityException) {
-            destination?.let(::releaseAfterCopyFailure)
             Result.failure(error)
         } catch (error: IllegalArgumentException) {
-            destination?.let(::releaseAfterCopyFailure)
             Result.failure(error)
+        } finally {
+            if (!copyCompleted) destination?.let(::releaseAfterCopyFailure)
         }
     }
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -150,7 +150,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
 
         return AppInfo(
             packageName = PackageName(packageInfo.packageName),
-            applicationName = applicationInfo?.loadLabel(packageManager).toString(),
+            applicationName = applicationInfo?.loadLabel(packageManager)?.toString() ?: packageInfo.packageName,
             processName = applicationInfo?.processName,
             versionName = packageInfo.versionName,
             versionCode = packageInfo.longVersionCode,

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppExportManagerImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppExportManagerImpl.kt
@@ -110,14 +110,17 @@ internal class AppExportManagerImpl @Inject constructor(
     }
 
     private suspend fun writeTo(destination: Uri, write: suspend (OutputStream) -> Unit) {
+        var writeCompleted = false
         try {
             val output = contentResolver.openOutputStream(destination, "w")
                 ?: error("The selected destination can not be opened")
             output.use { write(it) }
-        } catch (throwable: Throwable) {
-            runCatching { contentResolver.delete(destination, null, null) }
-                .onFailure { Logger.w(TAG, it, "Can not remove incomplete export") }
-            throw throwable
+            writeCompleted = true
+        } finally {
+            if (!writeCompleted) {
+                runCatching { contentResolver.delete(destination, null, null) }
+                    .onFailure { Logger.w(TAG, it, "Can not remove incomplete export") }
+            }
         }
     }
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -80,7 +80,7 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
             versionName = versionName,
             installTime = Instant.ofEpochMilli(firstInstallTime),
             lastUpdateTime = Instant.ofEpochMilli(lastUpdateTime),
-            requestedPermissions = requestedPermissions?.toList() ?: emptyList(),
+            requestedPermissions = requestedPermissions?.toList().orEmpty(),
         )
     }
 }

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/coroutines/RunCatching.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/coroutines/RunCatching.kt
@@ -2,7 +2,7 @@ package sk.styk.martin.apkanalyzer.core.common.coroutines
 
 import kotlin.coroutines.cancellation.CancellationException
 
-suspend inline fun <T> runCatchingCancellable(block: () -> T): Result<T> = runCatching(block).onFailure {
+inline fun <T> runCatchingCancellable(block: () -> T): Result<T> = runCatching(block).onFailure {
     if (it is CancellationException) {
         throw it
     }

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/digest/DigestManager.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/digest/DigestManager.kt
@@ -31,19 +31,19 @@ constructor() {
                 sb.append(0)
             }
 
-            sb.append(sTemp.uppercase(Locale.getDefault()))
+            sb.append(sTemp.uppercase(Locale.ROOT))
         }
 
         return sb.toString()
     }
 
-    private fun getHexString(digest: ByteArray): String = digest.joinToString("") { "%02x".format(it) }
+    private fun getHexString(digest: ByteArray): String = digest.joinToString("") { "%02x".format(Locale.ROOT, it) }
 
     private fun getDigest(algorithm: String): MessageDigest {
         try {
             return MessageDigest.getInstance(algorithm)
         } catch (e: NoSuchAlgorithmException) {
-            throw RuntimeException(e.message, e)
+            throw IllegalStateException("Digest algorithm is unavailable: $algorithm", e)
         }
     }
 

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/logger/Logger.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/logger/Logger.kt
@@ -6,12 +6,8 @@ import timber.log.Timber
 
 object Logger {
     fun init(logToConsole: Boolean) {
-        val trees =
-            buildList {
-                if (logToConsole) add(Timber.DebugTree())
-                add(FirebaseTree())
-            }
-        Timber.plant(*trees.toTypedArray())
+        if (logToConsole) Timber.plant(Timber.DebugTree())
+        Timber.plant(FirebaseTree())
     }
 
     fun v(tag: String, message: String) = Timber.tag(tag).v(message)
@@ -43,7 +39,7 @@ object Logger {
             message: String,
             t: Throwable?,
         ) {
-            FirebaseCrashlytics.getInstance().log("${priority.toPriorityChar()}/$tag: $message")
+            FirebaseCrashlytics.getInstance().log("${priority.toPriorityChar()}/${tag.orEmpty()}: $message")
             if (priority >= Log.WARN && t != null) {
                 FirebaseCrashlytics.getInstance().recordException(t)
             }

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/model/AppSize.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/model/AppSize.kt
@@ -1,5 +1,6 @@
 package sk.styk.martin.apkanalyzer.core.common.model
 
+import java.util.Locale
 import kotlin.math.abs
 
 @JvmInline
@@ -11,9 +12,9 @@ value class AppSize private constructor(val bytes: Long) : Comparable<AppSize> {
 
     fun formatted(): String = when {
         abs(bytes) < 1024L -> "$bytes B"
-        abs(bytes) < 1024L * 1024L -> "%.0f KB".format(kilobytes)
-        abs(bytes) < 1024L * 1024L * 1024L -> "%.1f MB".format(megabytes)
-        else -> "%.2f GB".format(gigabytes)
+        abs(bytes) < 1024L * 1024L -> "%.0f KB".format(Locale.getDefault(), kilobytes)
+        abs(bytes) < 1024L * 1024L * 1024L -> "%.1f MB".format(Locale.getDefault(), megabytes)
+        else -> "%.2f GB".format(Locale.getDefault(), gigabytes)
     }
 
     operator fun plus(other: AppSize): AppSize = AppSize(bytes + other.bytes)

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/settings/DataStorePersistenceRepository.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/settings/DataStorePersistenceRepository.kt
@@ -47,15 +47,15 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
 class DataStorePersistenceRepository
 @Inject
 constructor(@param:ApplicationContext private val context: Context) : PersistenceRepository {
-    override fun <T> observe(key: Key<T>): Flow<T> = context.dataStore.data.map { key.read(it) }
+    override fun <T : Any> observe(key: Key<T>): Flow<T> = context.dataStore.data.map { key.read(it) }
 
-    override suspend fun <T> get(key: Key<T>): T = context.dataStore.data.first().let { key.read(it) }
+    override suspend fun <T : Any> get(key: Key<T>): T = context.dataStore.data.first().let { key.read(it) }
 
-    override suspend fun <T> save(key: Key<T>, value: T) {
+    override suspend fun <T : Any> save(key: Key<T>, value: T) {
         context.dataStore.edit { prefs -> key.write(prefs, value) }
     }
 
-    private fun <T> Key<T>.read(prefs: Preferences): T = when (this) {
+    private fun <T : Any> Key<T>.read(prefs: Preferences): T = when (this) {
         Key.ColorScheme -> {
             when (prefs[KEY_COLOR_SCHEME]) {
                 "light" -> ColorAppScheme.Day
@@ -87,7 +87,7 @@ constructor(@param:ApplicationContext private val context: Context) : Persistenc
         }
     } as T
 
-    private fun <T> Key<T>.write(prefs: MutablePreferences, value: T) = when (this) {
+    private fun <T : Any> Key<T>.write(prefs: MutablePreferences, value: T) = when (this) {
         Key.ColorScheme -> {
             prefs[KEY_COLOR_SCHEME] =
                 when (value as ColorAppScheme) {

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/settings/Key.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/settings/Key.kt
@@ -1,17 +1,17 @@
 package sk.styk.martin.apkanalyzer.core.common.settings
 
-sealed class Key<T> {
-    data object ColorScheme : Key<ColorAppScheme>()
+sealed interface Key<T : Any> {
+    data object ColorScheme : Key<ColorAppScheme>
 
-    data object OnboardingRequired : Key<Boolean>()
+    data object OnboardingRequired : Key<Boolean>
 
-    data object AppStartNumber : Key<Int>()
+    data object AppStartNumber : Key<Int>
 
-    data object RecentlyViewedApps : Key<List<String>>()
+    data object RecentlyViewedApps : Key<List<String>>
 
-    data object RecentlyViewedAppsEnabled : Key<Boolean>()
+    data object RecentlyViewedAppsEnabled : Key<Boolean>
 
-    data object SearchHistory : Key<List<String>>()
+    data object SearchHistory : Key<List<String>>
 }
 
 enum class ColorAppScheme {

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/settings/PersistenceModule.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/settings/PersistenceModule.kt
@@ -8,8 +8,8 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class PersistenceModule {
+interface PersistenceModule {
     @Binds
     @Singleton
-    abstract fun bindPersistenceRepository(impl: DataStorePersistenceRepository): PersistenceRepository
+    fun bindPersistenceRepository(impl: DataStorePersistenceRepository): PersistenceRepository
 }

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/settings/PersistenceRepository.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/settings/PersistenceRepository.kt
@@ -3,9 +3,9 @@ package sk.styk.martin.apkanalyzer.core.common.settings
 import kotlinx.coroutines.flow.Flow
 
 interface PersistenceRepository {
-    fun <T> observe(key: Key<T>): Flow<T>
+    fun <T : Any> observe(key: Key<T>): Flow<T>
 
-    suspend fun <T> get(key: Key<T>): T
+    suspend fun <T : Any> get(key: Key<T>): T
 
-    suspend fun <T> save(key: Key<T>, value: T)
+    suspend fun <T : Any> save(key: Key<T>, value: T)
 }

--- a/core/navigation/src/main/kotlin/sk/styk/martin/apkanalyzer/core/navigation/NavigationState.kt
+++ b/core/navigation/src/main/kotlin/sk/styk/martin/apkanalyzer/core/navigation/NavigationState.kt
@@ -60,6 +60,6 @@ fun NavigationState.toEntries(entryProvider: (NavKey) -> NavEntry<NavKey>): Snap
     }
 
     return topLevelStack
-        .flatMap { decoratedEntries[it] ?: emptyList() }
+        .flatMap { decoratedEntries[it].orEmpty() }
         .toMutableStateList()
 }

--- a/core/user-preferences/src/main/kotlin/sk/styk/martin/apkanalyzer/core/userpreferences/RecentlyViewedAppsRepositoryImpl.kt
+++ b/core/user-preferences/src/main/kotlin/sk/styk/martin/apkanalyzer/core/userpreferences/RecentlyViewedAppsRepositoryImpl.kt
@@ -19,7 +19,7 @@ internal class RecentlyViewedAppsRepositoryImpl @Inject constructor(private val 
             if (enabled) {
                 combine(
                     persistenceRepository.observe(Key.RecentlyViewedApps),
-                    installedAppsRepository.apps().map { it.associateBy { it.packageName } },
+                    installedAppsRepository.apps().map { apps -> apps.associateBy { it.packageName } },
                 ) { recentPackages, installedApps ->
                     recentPackages.mapNotNull { installedApps[PackageName(it)] }
                 }

--- a/docs/technical/kotlin-code-quality.md
+++ b/docs/technical/kotlin-code-quality.md
@@ -151,7 +151,7 @@ combined with Detekt-driven refactoring.
 
 **Exit criteria**
 
-- Detekt fails CI for new findings.
+- Detekt fails CI for new error-severity findings.
 - No formatting rule is enforced by both Detekt and Spotless.
 - The repository has no Detekt baseline.
 
@@ -161,7 +161,7 @@ combined with Detekt-driven refactoring.
 
 **Changes**
 
-- Refactor baseline entries in small, behavior-preserving pull requests.
+- Refactor visible complexity findings in small, behavior-preserving pull requests.
 - Start with the largest screen files:
   - `AppDetailScreen.kt`;
   - `CertificatesScreen.kt`;

--- a/docs/technical/kotlin-code-quality.md
+++ b/docs/technical/kotlin-code-quality.md
@@ -169,11 +169,13 @@ combined with Detekt-driven refactoring.
   - `AppsScreen.kt`.
 - Extract cohesive UI sections and sample preview data into focused files.
 - Promote each complexity rule to blocking after its existing findings are fixed.
+- After all warning findings are resolved, make warning-severity findings fail Detekt.
 
 **Exit criteria**
 
 - No production Kotlin file exceeds the agreed class or method limits.
 - All enabled Detekt rules pass without a baseline.
+- Detekt fails CI for every error- or warning-severity finding.
 - Refactoring does not change user-visible behavior.
 
 ### KQ-05: Make diagnostics blocking

--- a/docs/technical/kotlin-code-quality.md
+++ b/docs/technical/kotlin-code-quality.md
@@ -127,7 +127,7 @@ combined with Detekt-driven refactoring.
 - All enabled ktlint and Compose rules pass.
 - The pull request contains no behavioral refactoring.
 
-### KQ-03: Add a curated Detekt baseline
+### KQ-03: Add curated Detekt analysis
 
 **Depends on:** KQ-01
 
@@ -142,15 +142,18 @@ combined with Detekt-driven refactoring.
   - cyclomatic complexity: 15;
   - nested block depth: 4.
 - Keep formatting, KDoc, `MagicNumber`, and aggressive `TooManyFunctions` rules disabled.
-- Fix high-confidence findings before creating a baseline.
-- Baseline only accepted legacy complexity that cannot be safely refactored in this step.
-- Add `detekt` to CI.
+- Run high-confidence checks with type resolution through Android variant tasks and the JVM main
+  source set.
+- Fix high-confidence findings before making the checks blocking.
+- Keep complexity findings non-blocking until the affected code is refactored.
+- Do not create a baseline. Stage rule severities instead of hiding accepted findings.
+- Run every Android module's `detektDebug` task and `build-logic:convention:detektMain` in CI.
 
 **Exit criteria**
 
 - Detekt fails CI for new findings.
 - No formatting rule is enforced by both Detekt and Spotless.
-- Every baseline entry has been reviewed rather than generated and accepted blindly.
+- The repository has no Detekt baseline.
 
 ### KQ-04: Pay down legacy complexity
 
@@ -165,12 +168,12 @@ combined with Detekt-driven refactoring.
   - `FilterScreen.kt`;
   - `AppsScreen.kt`.
 - Extract cohesive UI sections and sample preview data into focused files.
-- Remove each Detekt baseline entry in the same pull request that fixes it.
+- Promote each complexity rule to blocking after its existing findings are fixed.
 
 **Exit criteria**
 
 - No production Kotlin file exceeds the agreed class or method limits.
-- The Detekt baseline is empty, or contains only documented platform-generated exceptions.
+- All enabled Detekt rules pass without a baseline.
 - Refactoring does not change user-visible behavior.
 
 ### KQ-05: Make diagnostics blocking
@@ -222,7 +225,7 @@ focused architecture checks rather than AST lint rules.
 After all steps, the main quality gate should be equivalent to:
 
 ```shell
-./gradlew spotlessCheck detekt lintDebug :app:assembleDebug
+./gradlew spotlessCheck detektDebug :build-logic:convention:detektMain lintDebug :app:assembleDebug
 ```
 
 `spotlessApply` remains the only automatic formatting command. Detekt and Android Lint remain

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
@@ -367,33 +367,6 @@ private fun SectionHeader(title: String, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun DetailRow(
-    label: String,
-    value: String,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Text(
-            text = label,
-            style = AppTheme.typography.bodyMedium,
-            color = AppTheme.colors.onSurfaceVariant,
-            modifier = Modifier.weight(0.4f),
-        )
-        Text(
-            text = value,
-            style = AppTheme.typography.bodyMedium,
-            color = AppTheme.colors.onBackground,
-            modifier = Modifier.weight(0.6f),
-        )
-    }
-}
-
-@Composable
 private fun NavigableRow(
     label: String,
     value: String,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/navigation/AppDetailEntryProvider.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/navigation/AppDetailEntryProvider.kt
@@ -3,7 +3,6 @@ package sk.styk.martin.apkanalyzer.feature.appdetail.impl.navigation
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.util.openAppSystemPage
 import sk.styk.martin.apkanalyzer.core.common.util.openGooglePlay
 import sk.styk.martin.apkanalyzer.core.navigation.Navigator
@@ -18,8 +17,6 @@ import sk.styk.martin.apkanalyzer.feature.appdetail.impl.generalinfo.GeneralInfo
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.manifest.ManifestScreen
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.permissions.PermissionsScreen
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.requirements.RequirementsScreen
-
-private const val TAG = "AppDetailNavigation"
 
 fun EntryProviderScope<NavKey>.appDetailEntries(navigator: Navigator) {
     entry<AppDetailNavKey>(

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/requirements/RequirementsViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/requirements/RequirementsViewModel.kt
@@ -25,6 +25,7 @@ import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
+import java.util.Locale
 
 private const val TAG = "RequirementsViewModel"
 
@@ -124,7 +125,7 @@ private fun Feature.toRequirementItem(deviceFeatures: DeviceFeatures): Requireme
         is Feature.OpenGlEs -> RequirementItem.OpenGlEs(
             versionName = versionName,
             deviceVersionName = deviceFeatures.openGlEsVersionName,
-            identifier = "0x%08X".format(reqGlEsVersion),
+            identifier = "0x%08X".format(Locale.ROOT, reqGlEsVersion),
             isRequired = isRequired,
             availability = availability,
         )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ leakcanary = "2.14"
 coil = "3.5.0"
 spotless = "8.8.0"
 compose-rules-ktlint = "0.6.3"
+detekt = "2.0.0-alpha.6"
 
 [libraries]
 # AndroidX Core
@@ -93,6 +94,7 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 spotless-gradle-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 compose-rules-ktlint = { module = "io.nlopez.compose.rules:ktlint", version.ref = "compose-rules-ktlint" }
+detekt-gradle-plugin = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -106,6 +108,7 @@ google-services = { id = "com.google.gms.google-services", version.ref = "google
 crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics-plugin" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebase-perf-plugin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }
 apkanalyzer-library = { id = "apkanalyzer.library" }
 apkanalyzer-application = { id = "apkanalyzer.application" }
 apkanalyzer-agent-context = { id = "apkanalyzer.agent-context" }
@@ -113,6 +116,7 @@ apkanalyzer-feature-api = { id = "apkanalyzer.feature.api" }
 apkanalyzer-feature-impl = { id = "apkanalyzer.feature.impl" }
 apkanalyzer-hilt = { id = "apkanalyzer.hilt" }
 apkanalyzer-spotless = { id = "apkanalyzer.spotless" }
+apkanalyzer-detekt = { id = "apkanalyzer.detekt" }
 apkanalyzer-compose = { id = "apkanalyzer.compose" }
 
 [bundles]


### PR DESCRIPTION
Detekt adds semantic Kotlin checks that complement Spotless and Android Lint without hiding existing issues behind a baseline.

## What changed

- Adds Detekt 2.0.0-alpha.6 through a shared convention plugin for every Android module.
- Configures type-resolved `detektDebug` analysis for Android sources and `detektMain` for the convention-plugin JVM sources.
- Runs both task selectors in CI without analyzing the release variant twice.
- Uses a curated shared configuration where correctness findings block CI and existing complexity findings remain visible as warnings.
- Fixes the blocking findings exposed by the initial rollout, including cancellation-safe temporary-file cleanup and several null-safety and Kotlin idiom issues.
- Documents the baseline-free quality strategy and CI gate.

No Detekt baseline is introduced. The current 91 maintainability findings remain reported and can be reduced incrementally without weakening correctness enforcement.