### PR TITLE
Fix intent filter parsing gaps and display issues

### DIFF
--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -118,6 +118,15 @@ repositories and combine them while mapping to state.
   permits different component types to share the same class name.
 - Every filter preserves its actions, categories, data rules, priority, order, and link-verification
   request. Multiple `<data>` tags accumulate as rules on one filter, matching Android's semantics.
+  `host` and `port` are the one exception: Android pairs them per `<data>` tag into a single
+  authority match, so they are combined into one `Host` rule (`host:port`) instead of two
+  independently flattened rules — otherwise two `<data>` tags with different host/port combinations
+  would render as an ambiguous cross-product. A `port` without a `host` is dropped, matching
+  Android, which ignores it.
+- Reading every installed split manifest is required, not best-effort: if any split manifest cannot
+  be read, `componentIntentFilters()` fails for the whole package rather than silently returning
+  filters from only the splits it could read. Partial results would understate a component's real
+  entry points and read as "no intent filters" to callers that only check `Result.isSuccess`.
 
 ## External Entry Semantics
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/ManifestParserImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/ManifestParserImpl.kt
@@ -84,8 +84,8 @@ internal class ManifestParserImpl @Inject constructor(private val packageManager
             }
         }
 
-        if (manifests.size != expectedManifestCount) {
-            Logger.w(TAG, "Read ${manifests.size} of $expectedManifestCount installed manifests for $packageName")
+        check(manifests.size == expectedManifestCount) {
+            "Read ${manifests.size} of $expectedManifestCount installed manifests for $packageName"
         }
         return manifests.values.flatMap { it.filters }
     }
@@ -162,12 +162,20 @@ internal class ManifestParserImpl @Inject constructor(private val packageManager
                     CATEGORY_TAG -> parser.resolvedAndroidString(resources, NAME_ATTRIBUTE)?.let { currentFilter?.categories?.add(it) }
 
                     DATA_TAG -> currentFilter?.let { filter ->
-                        IntentFilterDataRuleType.entries.forEach { type ->
-                            parser.resolvedAndroidString(resources, type.manifestAttribute)?.let { value ->
-                                val rule = IntentFilterDataRule(type = type, value = value)
-                                currentUriRelativeGroup?.dataRules?.add(rule) ?: filter.dataRules.add(rule)
-                            }
+                        val rules = currentUriRelativeGroup?.dataRules ?: filter.dataRules
+                        val host = parser.resolvedAndroidString(resources, IntentFilterDataRuleType.Host.manifestAttribute)
+                        val port = parser.resolvedAndroidString(resources, IntentFilterDataRuleType.Port.manifestAttribute)
+                        if (host != null) {
+                            val authority = if (port != null) "$host:$port" else host
+                            rules.add(IntentFilterDataRule(type = IntentFilterDataRuleType.Host, value = authority))
                         }
+                        IntentFilterDataRuleType.entries
+                            .filterNot { it == IntentFilterDataRuleType.Host || it == IntentFilterDataRuleType.Port }
+                            .forEach { type ->
+                                parser.resolvedAndroidString(resources, type.manifestAttribute)?.let { value ->
+                                    rules.add(IntentFilterDataRule(type = type, value = value))
+                                }
+                            }
                     }
                 }
 
@@ -293,7 +301,10 @@ internal class ManifestParserImpl @Inject constructor(private val packageManager
         return if (resourceId == 0) {
             getAttributeValue(ANDROID_NAMESPACE, name)?.takeIf { it.isNotBlank() }
         } else {
-            resources.getString(resourceId).takeIf { it.isNotBlank() }
+            runCatching { resources.getString(resourceId) }
+                .onFailure { Logger.w(TAG, "Can not resolve string resource for attribute $name") }
+                .getOrNull()
+                ?.takeIf { it.isNotBlank() }
         }
     }
 
@@ -306,7 +317,9 @@ internal class ManifestParserImpl @Inject constructor(private val packageManager
         return if (resourceId == 0) {
             getAttributeIntValue(ANDROID_NAMESPACE, name, defaultValue)
         } else {
-            resources.getInteger(resourceId)
+            runCatching { resources.getInteger(resourceId) }
+                .onFailure { Logger.w(TAG, "Can not resolve integer resource for attribute $name") }
+                .getOrDefault(defaultValue)
         }
     }
 
@@ -319,7 +332,9 @@ internal class ManifestParserImpl @Inject constructor(private val packageManager
         return if (resourceId == 0) {
             getAttributeBooleanValue(ANDROID_NAMESPACE, name, defaultValue)
         } else {
-            resources.getBoolean(resourceId)
+            runCatching { resources.getBoolean(resourceId) }
+                .onFailure { Logger.w(TAG, "Can not resolve boolean resource for attribute $name") }
+                .getOrDefault(defaultValue)
         }
     }
 

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFilterDetailBottomSheet.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFilterDetailBottomSheet.kt
@@ -45,7 +45,7 @@ internal fun IntentFilterDetailBottomSheet(
             if (filter.actions.isNotEmpty()) {
                 DetailField(
                     label = stringResource(R.string.components_detail_intent_actions),
-                    value = filter.actions.joinToString(separator = "\n"),
+                    value = filter.actions.map { it.toDisplayRequestType() }.joinToString(separator = "\n"),
                     explanation = stringResource(R.string.components_detail_intent_actions_explanation),
                     onCopy = onCopy,
                 )
@@ -53,7 +53,7 @@ internal fun IntentFilterDetailBottomSheet(
             if (filter.categories.isNotEmpty()) {
                 DetailField(
                     label = stringResource(R.string.components_detail_intent_categories),
-                    value = filter.categories.joinToString(separator = "\n"),
+                    value = filter.categories.map { it.toDisplayCategory() }.joinToString(separator = "\n"),
                     explanation = stringResource(R.string.components_detail_intent_categories_explanation),
                     onCopy = onCopy,
                 )

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFilterMappings.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFilterMappings.kt
@@ -1,7 +1,10 @@
 package sk.styk.martin.apkanalyzer.feature.appdetail.impl.appcomponents
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import kotlinx.collections.immutable.toImmutableList
 import sk.styk.martin.apkanalyzer.core.apps.model.ComponentIntentFilter
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.R
 
 internal fun List<ComponentIntentFilter>.toItems() = mapIndexed { index, filter ->
     ComponentIntentFilterItem(
@@ -24,3 +27,20 @@ internal fun List<ComponentIntentFilter>.toItems() = mapIndexed { index, filter 
         isAutoVerify = filter.isAutoVerify,
     )
 }.toImmutableList()
+
+@Composable
+internal fun String.toDisplayRequestType(): String = if (startsWith(FRAMEWORK_ACTION_PREFIX)) {
+    removePrefix(FRAMEWORK_ACTION_PREFIX)
+} else {
+    stringResource(R.string.intent_filters_action_custom)
+}
+
+@Composable
+internal fun String.toDisplayCategory(): String = if (startsWith(FRAMEWORK_CATEGORY_PREFIX)) {
+    removePrefix(FRAMEWORK_CATEGORY_PREFIX)
+} else {
+    stringResource(R.string.intent_filters_category_custom)
+}
+
+private const val FRAMEWORK_ACTION_PREFIX = "android.intent.action."
+private const val FRAMEWORK_CATEGORY_PREFIX = "android.intent.category."

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFiltersScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFiltersScreen.kt
@@ -359,90 +359,70 @@ private fun ComponentIntentFilterItem.copyValue(): String = buildList {
 
 @StringRes
 internal fun ComponentIntentFilterItem.purposeTitleRes(componentType: ComponentType): Int {
-    if (actions.size > 1) {
-        return R.string.intent_filters_purpose_multiple
+    if (actions.isEmpty()) {
+        return R.string.intent_filters_filter_fallback
     }
-    val action = actions.singleOrNull()
-    return when (componentType) {
-        ComponentType.Activity -> when (action) {
-            Intent.ACTION_MAIN -> when {
-                Intent.CATEGORY_LAUNCHER in categories -> R.string.intent_filters_purpose_launcher
-                Intent.CATEGORY_LEANBACK_LAUNCHER in categories -> R.string.intent_filters_purpose_tv_launcher
-                else -> R.string.intent_filters_purpose_main
-            }
-
-            Intent.ACTION_VIEW -> R.string.intent_filters_purpose_view
-
-            Intent.ACTION_SEND,
-            Intent.ACTION_SEND_MULTIPLE,
-            -> R.string.intent_filters_purpose_share
-
-            Intent.ACTION_SENDTO -> R.string.intent_filters_purpose_send_to
-
-            Intent.ACTION_EDIT -> R.string.intent_filters_purpose_edit
-
-            Intent.ACTION_PICK,
-            Intent.ACTION_GET_CONTENT,
-            -> R.string.intent_filters_purpose_choose_content
-
-            Intent.ACTION_SEARCH,
-            Intent.ACTION_WEB_SEARCH,
-            -> R.string.intent_filters_purpose_search
-
-            Intent.ACTION_DIAL,
-            Intent.ACTION_CALL,
-            -> R.string.intent_filters_purpose_call
-
-            null -> R.string.intent_filters_filter_fallback
-
-            else -> R.string.intent_filters_purpose_activity_other
-        }
-
-        ComponentType.Receiver -> when (action) {
-            Intent.ACTION_BOOT_COMPLETED,
-            Intent.ACTION_LOCKED_BOOT_COMPLETED,
-            -> R.string.intent_filters_purpose_device_start
-
-            Intent.ACTION_PACKAGE_ADDED,
-            Intent.ACTION_PACKAGE_REMOVED,
-            Intent.ACTION_PACKAGE_CHANGED,
-            Intent.ACTION_PACKAGE_REPLACED,
-            Intent.ACTION_PACKAGE_RESTARTED,
-            -> R.string.intent_filters_purpose_app_change
-
-            Intent.ACTION_POWER_CONNECTED,
-            Intent.ACTION_POWER_DISCONNECTED,
-            -> R.string.intent_filters_purpose_power
-
-            null -> R.string.intent_filters_filter_fallback
-
-            else -> R.string.intent_filters_purpose_receiver_other
-        }
-
-        ComponentType.Service -> if (action == null) {
-            R.string.intent_filters_filter_fallback
-        } else {
-            R.string.intent_filters_purpose_service_other
-        }
-
-        ComponentType.Provider -> if (action == null) {
-            R.string.intent_filters_filter_fallback
-        } else {
-            R.string.intent_filters_purpose_provider_other
-        }
-    }
+    val resolvedTitles = actions.map { action -> purposeTitleRes(componentType, action) }.distinct()
+    return resolvedTitles.singleOrNull() ?: R.string.intent_filters_purpose_multiple
 }
 
-private fun String.toDisplayRequestType(): String = removePrefix(FRAMEWORK_ACTION_PREFIX)
-    .takeIf { it != this }
-    ?: this
+@StringRes
+private fun ComponentIntentFilterItem.purposeTitleRes(componentType: ComponentType, action: String): Int = when (componentType) {
+    ComponentType.Activity -> when (action) {
+        Intent.ACTION_MAIN -> when {
+            Intent.CATEGORY_LAUNCHER in categories -> R.string.intent_filters_purpose_launcher
+            Intent.CATEGORY_LEANBACK_LAUNCHER in categories -> R.string.intent_filters_purpose_tv_launcher
+            else -> R.string.intent_filters_purpose_main
+        }
 
-private fun String.toDisplayCategory(): String = removePrefix(FRAMEWORK_CATEGORY_PREFIX)
-    .takeIf { it != this }
-    ?: this
+        Intent.ACTION_VIEW -> R.string.intent_filters_purpose_view
 
-private const val FRAMEWORK_ACTION_PREFIX = "android.intent.action."
-private const val FRAMEWORK_CATEGORY_PREFIX = "android.intent.category."
+        Intent.ACTION_SEND,
+        Intent.ACTION_SEND_MULTIPLE,
+        -> R.string.intent_filters_purpose_share
+
+        Intent.ACTION_SENDTO -> R.string.intent_filters_purpose_send_to
+
+        Intent.ACTION_EDIT -> R.string.intent_filters_purpose_edit
+
+        Intent.ACTION_PICK,
+        Intent.ACTION_GET_CONTENT,
+        -> R.string.intent_filters_purpose_choose_content
+
+        Intent.ACTION_SEARCH,
+        Intent.ACTION_WEB_SEARCH,
+        -> R.string.intent_filters_purpose_search
+
+        Intent.ACTION_DIAL,
+        Intent.ACTION_CALL,
+        -> R.string.intent_filters_purpose_call
+
+        else -> R.string.intent_filters_purpose_activity_other
+    }
+
+    ComponentType.Receiver -> when (action) {
+        Intent.ACTION_BOOT_COMPLETED,
+        Intent.ACTION_LOCKED_BOOT_COMPLETED,
+        -> R.string.intent_filters_purpose_device_start
+
+        Intent.ACTION_PACKAGE_ADDED,
+        Intent.ACTION_PACKAGE_REMOVED,
+        Intent.ACTION_PACKAGE_CHANGED,
+        Intent.ACTION_PACKAGE_REPLACED,
+        Intent.ACTION_PACKAGE_RESTARTED,
+        -> R.string.intent_filters_purpose_app_change
+
+        Intent.ACTION_POWER_CONNECTED,
+        Intent.ACTION_POWER_DISCONNECTED,
+        -> R.string.intent_filters_purpose_power
+
+        else -> R.string.intent_filters_purpose_receiver_other
+    }
+
+    ComponentType.Service -> R.string.intent_filters_purpose_service_other
+
+    ComponentType.Provider -> R.string.intent_filters_purpose_provider_other
+}
 
 @Preview
 @Composable

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -404,6 +404,8 @@
         <item quantity="other">Search %1$d request rules</item>
     </plurals>
     <string name="intent_filters_filter_fallback">Intent filter</string>
+    <string name="intent_filters_action_custom">Custom action</string>
+    <string name="intent_filters_category_custom">Custom category</string>
     <string name="intent_filters_scheme">Scheme</string>
     <string name="intent_filters_path">Path</string>
     <string name="intent_filters_purpose_launcher">App launcher entry</string>


### PR DESCRIPTION
## Summary
- `componentIntentFilters()` now fails when a split manifest can't be read instead of silently returning partial data as a success — previously a component whose filters lived in an unread split would show as "no intent filters" instead of "unavailable."
- `host`/`port` on a single `<data>` tag are now paired into one `Host` rule (`host:port`), so multiple `<data>` tags with different host/port combinations no longer cross-combine into an ambiguous display.
- Resource-resolution failures in `resolvedAndroidString/Int/Boolean` now only drop the single attribute instead of aborting intent-filter parsing for the whole component tree.
- Custom/vendor intent actions and categories now fall back to "Custom action"/"Custom category" instead of leaking raw Android identifiers into the UI (row badges and the detail sheet).
- Filter purpose titles are now resolved per-action and only fall back to "Accepts several request types" when the actions genuinely disagree — common combos like `SEND`+`SEND_MULTIPLE` (share targets) or the `PACKAGE_*` set (install/uninstall receivers) now get a specific title.

## Test plan
- [x] `./gradlew :core:apps:compileDebugKotlin :feature:app-detail:impl:compileDebugKotlin`
- [x] `./gradlew spotlessApply` (no changes)
- [ ] Manual verification on device via the Components → intent filters screen