### PR TITLE
Fix crash when typing in app search

### DIFF
--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/search/AppSearchScreen.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/search/AppSearchScreen.kt
@@ -154,7 +154,7 @@ private fun SearchResults(results: ImmutableList<AppListItem>, onAppClick: (AppL
     ) {
         itemsPositioned(
             items = results,
-            key = { _, app -> app.packageName },
+            key = { _, app -> app.packageName.value },
         ) { position, app ->
             AppListItemRow(
                 app = app,


### PR DESCRIPTION
Typing in the app-list search could crash because the lazy list item key used `PackageName`, which is not a Bundle-saveable type in Compose state restoration.

This switches the search results key to `packageName.value` so the key is a stable `String`. Behavior is unchanged except the crash path is removed.