### PR TITLE
Add Browse by Attribute (CE-05)

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -55,7 +55,7 @@ internal fun ApkAnalyzerApp() {
                 val entryProvider = entryProvider {
                     appEntries(navigator)
                     appDetailEntries(navigator)
-                    browseEntries()
+                    browseEntries(navigator)
                     settingsEntries(navigator)
                 }
                 NavDisplay(
@@ -70,11 +70,10 @@ internal fun ApkAnalyzerApp() {
 ```
 
 `AppsNavKey` is the start destination. Each `*Entries()` call comes from the corresponding
-`feature/*/impl/navigation/*EntryProvider.kt` and only takes a `navigator` param when that
-feature navigates *out* to another feature (apps, app-detail, settings do; browse
-currently doesn't since it's a stub screen — see its own `AGENTS.md`). **Adding a new
-feature/screen means adding its `*Entries()` call here** — see the `create-feature-module` and
-`implement-navigation` skills.
+`feature/*/impl/navigation/*EntryProvider.kt` and takes a `navigator` param whenever that feature
+navigates *out* to another feature — all four registered here do (browse navigates into
+`feature:app-detail` from its apps screen). **Adding a new feature/screen means adding its
+`*Entries()` call here** — see the `create-feature-module` and `implement-navigation` skills.
 
 ## Manifest Highlights (`app/src/main/AndroidManifest.xml`)
 

--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/ApkAnalyzerApp.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/ApkAnalyzerApp.kt
@@ -43,7 +43,7 @@ internal fun ApkAnalyzerApp() {
                     val entryProvider = entryProvider {
                         appEntries(navigator)
                         appDetailEntries(navigator)
-                        browseEntries()
+                        browseEntries(navigator)
                         settingsEntries(navigator)
                     }
                     NavDisplay(

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -73,20 +73,20 @@ flag (`GET_CONFIGURATIONS`) with no other `core:apps` consumer yet, unlike certi
 
 | ID    | Item                                | Status  | Notes                                                                                     |
 |-------|-------------------------------------|---------|--------------------------------------------------------------------------------------------|
-| CE-01 | Attribute index infrastructure      | Partial | `core:app-index` ships target SDK, min SDK, install source, permission, certificate. Data layer only — no UI yet, see `CE-05` |
-| CE-05 | Browse screen                       | Todo    | Dimension picker → bucket list with counts → app list. One screen serves every dimension  |
-| FR-08 | ↳ dimension: permission             | Partial | Indexed in `core:app-index` (free — already on `InstalledApp`); multi-permission filter also works in `feature:apps`; no browse UI yet |
-| FR-09 | ↳ dimension: signing certificate    | Partial | Indexed in `core:app-index` by fingerprint, organization, and country via the new `AppSigningRepository` (`core:apps`) — no browse UI yet |
-| FR-40 | ↳ dimension: target SDK / min SDK   | Partial | Indexed in `core:app-index`. This is what the SDK chart was, made tappable — no browse UI yet |
-| FR-41 | ↳ dimension: install source         | Partial | Indexed in `core:app-index` — no browse UI yet                                            |
+| CE-01 | Attribute index infrastructure      | Done    | `core:app-index` ships target SDK, min SDK, install source, permission, certificate, consumed end to end by `CE-05` |
+| CE-05 | Browse screen                       | Done    | `feature:browse` — dimension cards (hub) → bucket list with counts (options) → app list (apps) → `feature:app-detail`. One screen shape serves every dimension |
+| FR-08 | ↳ dimension: permission             | Done    | Bucket label from `PermissionLabelProvider` (`core:app-permissions`); raw permission name shown as the identifier |
+| FR-09 | ↳ dimension: signing certificate    | Done    | Bucketed by signer organization (`certificateOrganization`); fingerprint and country stay indexed in `core:app-index` but are not separate browse dimensions in this pass |
+| FR-40 | ↳ dimension: target SDK / min SDK   | Done    | Bucket label from `SdkVersionResolver` (`core:apps`), e.g. "Android 14"; raw API level shown as the identifier |
+| FR-41 | ↳ dimension: install source         | Done    | Google Play / System / Unknown, three buckets                                             |
 | FR-42 | ↳ dimension: shared UID             | Todo    | Needs `FR-35`                                                                             |
 | FR-43 | ↳ dimension: app category           | Todo    | Needs `FR-39`                                                                             |
-| CE-06 | "Also signed with this certificate" | Backlog | The other installed apps sharing this signer, listed on the app detail certificate screen. Data is already extracted; it needs the `CE-01` index. **Revisit when CE-01 / FR-09 certificate grouping is built** — see [features/app-detail.md](features/app-detail.md#deferred) |
+| CE-06 | "Also signed with this certificate" | Backlog | The other installed apps sharing this signer, listed on the app detail certificate screen. Data is already extracted; it needs a fingerprint-keyed lookup instead of `CE-05`'s organization-keyed bucket. **Revisit when that lookup is built** — see [features/app-detail.md](features/app-detail.md#deferred) |
 
 **Module consolidation: done.** `feature:permissions` and `feature:statistics` — both placeholder
-screens each holding a top-level nav slot — are deleted and collapsed into one `feature:browse`
-(currently also a placeholder, pending `CE-05`). That frees a bottom-nav slot — the natural home for
-Pillar 1's What Changed tab in R1.
+screens each holding a top-level nav slot — are deleted and collapsed into one `feature:browse`,
+now fully implemented per `CE-05`. That frees a bottom-nav slot — the natural home for Pillar 1's
+What Changed tab in R1.
 
 ### 1.2 App Detail
 

--- a/feature/browse/AGENTS.md
+++ b/feature/browse/AGENTS.md
@@ -2,16 +2,15 @@
 
 ## Purpose
 Bottom-navigation top-level destination for "Browse by Attribute" (tab label "Browse") — roadmap
-`CE-05`: pick a dimension, see its bucket counts, tap a bucket to see the apps in it. **Status:
-stub/placeholder — not yet implemented.** Currently renders only centered "Browse" text, no state, no
-ViewModel, no logic. Do not assume this feature has real behavior — check before referencing it in
-other work. Replaces the former `feature:permissions` and `feature:statistics` stub tabs, per
-`docs/product/roadmap.md` §1.1b's module consolidation note.
+`CE-05`: pick a dimension, see its bucket counts, tap a bucket to see the apps in it. Three depths,
+one screen each: hub (dimension cards) → options (bucket list for the chosen dimension) → apps
+(the apps in the tapped bucket) → `feature:app-detail`. Replaces the former `feature:permissions` and
+`feature:statistics` stub tabs, per `docs/product/roadmap.md` §1.1b's module consolidation note.
 
 ## Sub-modules
 - `api` — Contains `BrowseNavKey` (top-level destination) and the "Browse" string resource used as
   the bottom-nav tab label
-- `impl` — Placeholder screen only
+- `impl` — Full implementation
 
 ## Package: `sk.styk.martin.apkanalyzer.feature.browse.impl`
 
@@ -25,21 +24,45 @@ object BrowseNavKey : NavKey
 ## Impl Structure
 
 ```
+model/
+  BrowseDimension.kt        - @Serializable enum: Permission, SigningCertificate, TargetSdk, MinSdk, InstallSource
+domain/
+  BrowseBuckets.kt           - AppAttributeIndex.bucketsFor(dimension): Map<String, List<PackageName>>,
+                                normalizing every dimension's key type (Int, AppSource, String?) to String.
+                                UNKNOWN_SIGNER_KEY is the sentinel for a null certificate organization
+  BrowseDimensionLabeler.kt  - @Inject; resolves a dimension+key pair to a friendly label and an
+                                optional raw identifier. Wraps PermissionLabelProvider (core:app-permissions)
+                                and SdkVersionResolver (core:apps) for the two dimensions that need a
+                                real lookup; the enum-backed dimensions (install source, unknown signer)
+                                resolve directly from this module's own strings.xml via Context.getString
+                                — deliberately not through Compose stringResource, since this runs outside
+                                a @Composable in the ViewModel/domain layer
+BrowseDimensionResources.kt  - Composable-only per-dimension icon/title/subtitle, shared by all three screens
+BrowseState.kt / BrowseAction.kt / BrowseEvent.kt / BrowseViewModel.kt / BrowseScreen.kt
+                              - Hub: dimension cards with a top-labels preview row and an option count,
+                                sourced straight from AppIndexRepository.index() + InstalledAppsRepository.apps()
+options/                      - Bucket list for one dimension (search + sorted-by-count rows)
+apps/                         - Apps in one tapped bucket (search + app rows), re-derives the bucket's
+                                package set live from the index rather than carrying it through the NavKey
 navigation/
-  BrowseEntryProvider.kt  - browseEntries(): EntryProviderScope<NavKey> extension, registers BrowseNavKey -> BrowseScreen()
-BrowseScreen.kt            - @Composable stub: centered "Browse" text, with @Preview
+  BrowseEntryProvider.kt      - browseEntries(navigator): registers BrowseNavKey, BrowseOptionsNavKey,
+                                BrowseAppsNavKey; the apps screen navigates out to AppDetailNavKey
+  BrowseOptionsNavKey.kt      - Internal: dimension
+  BrowseAppsNavKey.kt         - Internal: dimension, bucketKey, bucketLabel
 ```
 
-Takes no `Navigator` parameter since the placeholder screen doesn't navigate anywhere.
+None of the three screens have an error state — `AppIndexStatus` is `Loading | Data`, never a failure,
+since it is pure bucketing over flows that already can't fail. Loading is the only non-loaded state
+each ViewModel exposes.
 
-## When Implementing This Feature
-
-The real feature is expected to consume `core:app-index`'s `AppIndexRepository` (dimension → bucket →
-package-name index, built off `InstalledAppsRepository` — see `core/app-index/AGENTS.md`) for the
-dimension picker and bucket-count list, then navigate to `feature:app-detail`'s `AppDetailNavKey` per
-tapped app. Follow the MVVM pattern used by `feature:settings` or `feature:apps` (State/Action/Event +
-`@HiltViewModel`) rather than inventing a new shape.
+The apps screen does not carry the bucket's package list through the NavKey. It re-combines
+`AppIndexRepository.index()` with `InstalledAppsRepository.apps()` using the dimension and raw bucket
+key alone, so the list stays live (uninstalling an app while viewing its bucket updates the screen)
+and the NavKey stays small.
 
 ## Dependencies
 - `api`: `apkanalyzer.feature.api` plugin, no explicit dependencies
-- `impl`: `apkanalyzer.feature.impl` plugin, `api(projects.feature.browse.api)` only
+- `impl`: `apkanalyzer.feature.impl` plugin, `api(projects.feature.browse.api)`,
+  `implementation(projects.feature.appDetail.api)`, `implementation(projects.core.appIndex)`,
+  `implementation(projects.core.apps)`, `implementation(projects.core.appPermissions)`,
+  `implementation(projects.core.common)`, `kotlinx-collections-immutable`

--- a/feature/browse/impl/build.gradle.kts
+++ b/feature/browse/impl/build.gradle.kts
@@ -4,12 +4,14 @@ plugins {
 
 android {
     namespace = "sk.styk.martin.apkanalyzer.feature.browse.impl"
-
-    buildFeatures {
-        androidResources = false
-    }
 }
 
 dependencies {
     api(projects.feature.browse.api)
+    implementation(projects.feature.appDetail.api)
+    implementation(projects.core.appIndex)
+    implementation(projects.core.apps)
+    implementation(projects.core.appPermissions)
+    implementation(projects.core.common)
+    implementation(libs.kotlinx.collections.immutable)
 }

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseAction.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseAction.kt
@@ -1,0 +1,7 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl
+
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+internal sealed interface BrowseAction {
+    data class SelectDimension(val dimension: BrowseDimension) : BrowseAction
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseDimensionResources.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseDimensionResources.kt
@@ -1,0 +1,36 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+internal fun BrowseDimension.icon(): ImageVector = when (this) {
+    BrowseDimension.Permission -> ApkAnalyzerIcons.Permissions
+    BrowseDimension.SigningCertificate -> ApkAnalyzerIcons.Fingerprint
+    BrowseDimension.TargetSdk, BrowseDimension.MinSdk -> ApkAnalyzerIcons.Android
+    BrowseDimension.InstallSource -> ApkAnalyzerIcons.Folder
+}
+
+@Composable
+internal fun BrowseDimension.title(): String = stringResource(
+    when (this) {
+        BrowseDimension.Permission -> R.string.browse_dimension_permission_title
+        BrowseDimension.SigningCertificate -> R.string.browse_dimension_certificate_title
+        BrowseDimension.TargetSdk -> R.string.browse_dimension_target_sdk_title
+        BrowseDimension.MinSdk -> R.string.browse_dimension_min_sdk_title
+        BrowseDimension.InstallSource -> R.string.browse_dimension_install_source_title
+    },
+)
+
+@Composable
+internal fun BrowseDimension.subtitle(): String = stringResource(
+    when (this) {
+        BrowseDimension.Permission -> R.string.browse_dimension_permission_subtitle
+        BrowseDimension.SigningCertificate -> R.string.browse_dimension_certificate_subtitle
+        BrowseDimension.TargetSdk -> R.string.browse_dimension_target_sdk_subtitle
+        BrowseDimension.MinSdk -> R.string.browse_dimension_min_sdk_subtitle
+        BrowseDimension.InstallSource -> R.string.browse_dimension_install_source_subtitle
+    },
+)

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseEvent.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseEvent.kt
@@ -1,0 +1,7 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl
+
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+internal sealed interface BrowseEvent {
+    data class NavigateToDimension(val dimension: BrowseDimension) : BrowseEvent
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseScreen.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseScreen.kt
@@ -1,28 +1,277 @@
 package sk.styk.martin.apkanalyzer.feature.browse.impl
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Chip
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.ChipVariant
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Icon
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.SkeletonBox
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.Text
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.navigationBarContentPadding
+import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.Shapes
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
 
 @Composable
-internal fun BrowseScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
+internal fun BrowseScreen(
+    onOpenDimension: (BrowseDimension) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: BrowseViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is BrowseEvent.NavigateToDimension -> onOpenDimension(event.dimension)
+            }
+        }
+    }
+
+    BrowseContent(
+        state = state,
+        onAction = viewModel::onAction,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun BrowseContent(
+    state: BrowseState,
+    onAction: (BrowseAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(AppTheme.colors.background),
     ) {
-        Text(text = "Browse")
+        BrowseHeader(state = state)
+
+        when (state) {
+            is BrowseState.Loading -> BrowseLoadingList()
+
+            is BrowseState.Loaded -> Column(
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(start = 16.dp, end = 16.dp, bottom = navigationBarContentPadding + 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                state.dimensions.forEach { summary ->
+                    DimensionCard(
+                        summary = summary,
+                        onClick = { onAction(BrowseAction.SelectDimension(summary.dimension)) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BrowseHeader(state: BrowseState, modifier: Modifier = Modifier) {
+    Column(modifier = modifier.padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 12.dp)) {
+        Text(
+            text = stringResource(R.string.browse_title),
+            style = AppTheme.typography.headlineSmall,
+            color = AppTheme.colors.onBackground,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = when (state) {
+                is BrowseState.Loading -> stringResource(R.string.browse_subtitle_loading)
+                is BrowseState.Loaded -> pluralStringResource(R.plurals.browse_subtitle, state.totalApps, state.totalApps)
+            },
+            style = AppTheme.typography.bodyMedium,
+            color = AppTheme.colors.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun DimensionCard(
+    summary: DimensionSummary,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(Shapes.CardShape)
+            .background(AppTheme.colors.surface)
+            .clickable(onClick = onClick)
+            .padding(16.dp),
+    ) {
+        Row(verticalAlignment = Alignment.Top) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .size(44.dp)
+                    .background(AppTheme.colors.primaryContainer, CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = summary.dimension.icon(),
+                    tint = AppTheme.colors.primary,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+            Spacer(modifier = Modifier.width(14.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = summary.dimension.title(),
+                    style = AppTheme.typography.titleMedium,
+                    color = AppTheme.colors.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = summary.dimension.subtitle(),
+                    style = AppTheme.typography.bodySmall,
+                    color = AppTheme.colors.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Icon(
+                imageVector = ApkAnalyzerIcons.ChevronRight,
+                tint = AppTheme.colors.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+
+        if (summary.topLabels.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState(), enabled = false)
+                    .padding(start = 60.dp),
+            ) {
+                summary.topLabels.forEach { label ->
+                    Chip(label = label, variant = ChipVariant.Tonal)
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = pluralStringResource(R.plurals.browse_dimension_option_count, summary.optionCount, summary.optionCount),
+            style = AppTheme.typography.labelMedium,
+            color = AppTheme.colors.primary,
+            modifier = Modifier.padding(start = 60.dp),
+        )
+    }
+}
+
+@Composable
+private fun BrowseLoadingList(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        repeat(5) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(Shapes.CardShape)
+                    .background(AppTheme.colors.surface)
+                    .padding(16.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    SkeletonBox(modifier = Modifier.size(44.dp).clip(CircleShape))
+                    Spacer(modifier = Modifier.width(14.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        SkeletonBox(modifier = Modifier.fillMaxWidth(0.5f).height(16.dp))
+                        Spacer(modifier = Modifier.height(6.dp))
+                        SkeletonBox(modifier = Modifier.fillMaxWidth(0.8f).height(12.dp))
+                    }
+                }
+            }
+        }
     }
 }
 
 @Preview
 @Composable
-private fun BrowseScreenPreview() {
+private fun BrowseContentLoadingPreview() {
     ApkAnalyzerTheme {
-        BrowseScreen()
+        BrowseContent(state = BrowseState.Loading, onAction = {})
     }
 }
+
+@Preview
+@Composable
+private fun BrowseContentLoadedPreview() {
+    ApkAnalyzerTheme {
+        BrowseContent(state = sampleLoadedState(), onAction = {})
+    }
+}
+
+private fun sampleLoadedState() = BrowseState.Loaded(
+    totalApps = 187,
+    dimensions = persistentListOf(
+        DimensionSummary(
+            dimension = BrowseDimension.Permission,
+            optionCount = 143,
+            topLabels = persistentListOf("Full network access", "Camera", "Precise location", "Contacts"),
+        ),
+        DimensionSummary(
+            dimension = BrowseDimension.SigningCertificate,
+            optionCount = 96,
+            topLabels = persistentListOf("Google LLC", "Samsung Electronics", "Unknown signer"),
+        ),
+        DimensionSummary(
+            dimension = BrowseDimension.TargetSdk,
+            optionCount = 12,
+            topLabels = persistentListOf("Android 14", "Android 13", "Android 15"),
+        ),
+        DimensionSummary(
+            dimension = BrowseDimension.MinSdk,
+            optionCount = 9,
+            topLabels = persistentListOf("Android 8.0", "Android 7.0", "Android 10"),
+        ),
+        DimensionSummary(
+            dimension = BrowseDimension.InstallSource,
+            optionCount = 3,
+            topLabels = persistentListOf("Google Play", "System", "Unknown"),
+        ),
+    ).toImmutableList(),
+)

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseState.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseState.kt
@@ -1,0 +1,21 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl
+
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+@Immutable
+internal sealed interface BrowseState {
+
+    data object Loading : BrowseState
+
+    @Immutable
+    data class Loaded(val totalApps: Int, val dimensions: ImmutableList<DimensionSummary>) : BrowseState
+}
+
+@Immutable
+internal data class DimensionSummary(
+    val dimension: BrowseDimension,
+    val optionCount: Int,
+    val topLabels: ImmutableList<String>,
+)

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseViewModel.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseViewModel.kt
@@ -1,0 +1,71 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import sk.styk.martin.apkanalyzer.core.appindex.AppIndexRepository
+import sk.styk.martin.apkanalyzer.core.appindex.model.AppIndexStatus
+import sk.styk.martin.apkanalyzer.core.apps.InstalledAppsRepository
+import sk.styk.martin.apkanalyzer.core.apps.model.InstalledApp
+import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.feature.browse.impl.domain.BrowseDimensionLabeler
+import sk.styk.martin.apkanalyzer.feature.browse.impl.domain.CERTIFICATE_ORGANIZATION
+import sk.styk.martin.apkanalyzer.feature.browse.impl.domain.bucketsFor
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+import javax.inject.Inject
+
+private const val TOP_LABELS_COUNT = 4
+
+@HiltViewModel
+internal class BrowseViewModel @Inject constructor(
+    appIndexRepository: AppIndexRepository,
+    installedAppsRepository: InstalledAppsRepository,
+    private val labeler: BrowseDimensionLabeler,
+    dispatcherProvider: DispatcherProvider,
+) : ViewModel() {
+
+    val state: StateFlow<BrowseState> = combine(
+        appIndexRepository.index(),
+        installedAppsRepository.apps(),
+    ) { status, apps -> status.toBrowseState(apps) }
+        .flowOn(dispatcherProvider.io())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), BrowseState.Loading)
+
+    private val eventChannel = Channel<BrowseEvent>(Channel.BUFFERED)
+    val events = eventChannel.receiveAsFlow()
+
+    fun onAction(action: BrowseAction) {
+        when (action) {
+            is BrowseAction.SelectDimension -> eventChannel.trySend(BrowseEvent.NavigateToDimension(action.dimension))
+        }
+    }
+
+    private fun AppIndexStatus.toBrowseState(apps: List<InstalledApp>): BrowseState = when (this) {
+        AppIndexStatus.Loading -> BrowseState.Loading
+
+        is AppIndexStatus.Data -> BrowseState.Loaded(
+            totalApps = apps.size,
+            dimensions = BrowseDimension.entries.map { dimension ->
+                val previewSubKey = if (dimension == BrowseDimension.SigningCertificate) CERTIFICATE_ORGANIZATION else null
+                val buckets = index.bucketsFor(dimension, previewSubKey)
+                DimensionSummary(
+                    dimension = dimension,
+                    optionCount = index.bucketsFor(dimension).size,
+                    topLabels = buckets.entries
+                        .sortedByDescending { it.value.size }
+                        .take(TOP_LABELS_COUNT)
+                        .map { labeler.label(dimension, it.key, previewSubKey) }
+                        .toImmutableList(),
+                )
+            }.toImmutableList(),
+        )
+    }
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsAction.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsAction.kt
@@ -1,0 +1,8 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.apps
+
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+
+internal sealed interface BrowseAppsAction {
+    data class ChangeQuery(val query: String) : BrowseAppsAction
+    data class AppClicked(val packageName: PackageName) : BrowseAppsAction
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsEvent.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsEvent.kt
@@ -1,0 +1,7 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.apps
+
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+
+internal sealed interface BrowseAppsEvent {
+    data class NavigateToAppDetail(val packageName: PackageName) : BrowseAppsEvent
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsScreen.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsScreen.kt
@@ -1,0 +1,241 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.apps
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import sk.styk.martin.apkanalyzer.core.common.model.AppReference
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.AppIcon
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.LoadingSpinner
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.SearchBarActive
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Text
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Toolbar
+import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.collapsingHeader
+import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.collapsingHeaderContainer
+import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.rememberCollapsingHeaderState
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.Shapes
+import sk.styk.martin.apkanalyzer.feature.browse.impl.R
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+@Composable
+internal fun BrowseAppsScreen(
+    dimension: BrowseDimension,
+    bucketKey: String,
+    bucketLabel: String,
+    subAttribute: String?,
+    onBack: () -> Unit,
+    onOpenApp: (PackageName) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: BrowseAppsViewModel = hiltViewModel { factory: BrowseAppsViewModel.Factory ->
+        factory.create(dimension, bucketKey, subAttribute)
+    },
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is BrowseAppsEvent.NavigateToAppDetail -> onOpenApp(event.packageName)
+            }
+        }
+    }
+
+    BrowseAppsContent(
+        bucketLabel = bucketLabel,
+        state = state,
+        onAction = viewModel::onAction,
+        onBack = onBack,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun BrowseAppsContent(
+    bucketLabel: String,
+    state: BrowseAppsState,
+    onAction: (BrowseAppsAction) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(AppTheme.colors.background),
+    ) {
+        Toolbar(title = bucketLabel, onBack = onBack)
+
+        when (state) {
+            is BrowseAppsState.Loading -> Box(modifier = Modifier.fillMaxSize()) {
+                LoadingSpinner(modifier = Modifier.align(Alignment.Center))
+            }
+
+            is BrowseAppsState.Loaded -> BrowseAppsList(state = state, onAction = onAction)
+        }
+    }
+}
+
+@Composable
+private fun BrowseAppsList(
+    state: BrowseAppsState.Loaded,
+    onAction: (BrowseAppsAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val collapsingState = rememberCollapsingHeaderState()
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .clipToBounds()
+            .collapsingHeaderContainer(collapsingState),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .offset { collapsingState.headerOffset }
+                .background(AppTheme.colors.background)
+                .collapsingHeader(collapsingState),
+        ) {
+            SearchBarActive(
+                query = state.query,
+                placeholder = pluralStringResource(R.plurals.browse_apps_filter_hint, state.totalApps, state.totalApps),
+                onQueryChange = { onAction(BrowseAppsAction.ChangeQuery(it)) },
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+
+        if (state.apps.isNotEmpty()) {
+            LazyColumn(
+                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .offset { collapsingState.contentOffset },
+            ) {
+                items(items = state.apps, key = { it.packageName.value }) { app ->
+                    BrowseAppRow(
+                        app = app,
+                        onClick = { onAction(BrowseAppsAction.AppClicked(app.packageName)) },
+                    )
+                }
+            }
+        } else {
+            Text(
+                text = stringResource(R.string.browse_apps_empty_query, state.query),
+                style = AppTheme.typography.bodyLarge,
+                color = AppTheme.colors.onBackground,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .offset { collapsingState.contentOffset }
+                    .padding(horizontal = 32.dp, vertical = 48.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BrowseAppRow(
+    app: BrowseAppItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(Shapes.CardShape)
+            .background(AppTheme.colors.surface)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+    ) {
+        AppIcon(source = AppReference.InstalledPackage(app.packageName))
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = app.applicationName,
+                style = AppTheme.typography.titleSmall,
+                color = AppTheme.colors.onBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = app.packageName.value,
+                style = AppTheme.typography.bodySmall,
+                color = AppTheme.colors.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun BrowseAppsLoadingPreview() {
+    ApkAnalyzerTheme {
+        BrowseAppsContent(bucketLabel = "Camera", state = BrowseAppsState.Loading, onAction = {}, onBack = {})
+    }
+}
+
+@Preview
+@Composable
+private fun BrowseAppsLoadedPreview() {
+    ApkAnalyzerTheme {
+        BrowseAppsContent(bucketLabel = "Camera", state = sampleLoadedState(), onAction = {}, onBack = {})
+    }
+}
+
+@Preview
+@Composable
+private fun BrowseAppsEmptyPreview() {
+    ApkAnalyzerTheme {
+        BrowseAppsContent(
+            bucketLabel = "Camera",
+            state = sampleLoadedState().copy(query = "xyz", apps = persistentListOf()),
+            onAction = {},
+            onBack = {},
+        )
+    }
+}
+
+private fun sampleLoadedState() = BrowseAppsState.Loaded(
+    query = "",
+    totalApps = 2,
+    apps = persistentListOf(
+        BrowseAppItem(packageName = PackageName("com.instagram.android"), applicationName = "Instagram"),
+        BrowseAppItem(packageName = PackageName("com.spotify.music"), applicationName = "Spotify"),
+    ).toImmutableList(),
+)

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsState.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsState.kt
@@ -1,0 +1,21 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.apps
+
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+
+@Immutable
+internal sealed interface BrowseAppsState {
+
+    data object Loading : BrowseAppsState
+
+    @Immutable
+    data class Loaded(
+        val query: String,
+        val totalApps: Int,
+        val apps: ImmutableList<BrowseAppItem>,
+    ) : BrowseAppsState
+}
+
+@Immutable
+internal data class BrowseAppItem(val packageName: PackageName, val applicationName: String)

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsViewModel.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsViewModel.kt
@@ -1,0 +1,89 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.apps
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import sk.styk.martin.apkanalyzer.core.appindex.AppIndexRepository
+import sk.styk.martin.apkanalyzer.core.appindex.model.AppIndexStatus
+import sk.styk.martin.apkanalyzer.core.apps.InstalledAppsRepository
+import sk.styk.martin.apkanalyzer.core.apps.model.InstalledApp
+import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.feature.browse.impl.domain.bucketsFor
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+@HiltViewModel(assistedFactory = BrowseAppsViewModel.Factory::class)
+internal class BrowseAppsViewModel @AssistedInject constructor(
+    @Assisted private val dimension: BrowseDimension,
+    @Assisted("bucketKey") private val bucketKey: String,
+    @Assisted("subAttribute") private val subAttribute: String?,
+    appIndexRepository: AppIndexRepository,
+    installedAppsRepository: InstalledAppsRepository,
+    dispatcherProvider: DispatcherProvider,
+) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            dimension: BrowseDimension,
+            @Assisted("bucketKey") bucketKey: String,
+            @Assisted("subAttribute") subAttribute: String?,
+        ): BrowseAppsViewModel
+    }
+
+    private val query = MutableStateFlow("")
+
+    val state: StateFlow<BrowseAppsState> = combine(
+        appIndexRepository.index(),
+        installedAppsRepository.apps(),
+        query,
+    ) { status, apps, query -> status.toAppsState(apps, query) }
+        .flowOn(dispatcherProvider.default())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), BrowseAppsState.Loading)
+
+    private val eventChannel = Channel<BrowseAppsEvent>(Channel.BUFFERED)
+    val events = eventChannel.receiveAsFlow()
+
+    fun onAction(action: BrowseAppsAction) {
+        when (action) {
+            is BrowseAppsAction.ChangeQuery -> query.value = action.query
+            is BrowseAppsAction.AppClicked -> eventChannel.trySend(BrowseAppsEvent.NavigateToAppDetail(action.packageName))
+        }
+    }
+
+    private fun AppIndexStatus.toAppsState(apps: List<InstalledApp>, query: String): BrowseAppsState = when (this) {
+        AppIndexStatus.Loading -> BrowseAppsState.Loading
+
+        is AppIndexStatus.Data -> {
+            val bucketPackages = index.bucketsFor(dimension, subAttribute)[bucketKey].orEmpty().toSet()
+            val bucketApps = apps
+                .filter { it.packageName in bucketPackages }
+                .sortedBy { it.applicationName.lowercase() }
+                .map { BrowseAppItem(packageName = it.packageName, applicationName = it.applicationName) }
+
+            val filtered = bucketApps.filter { app ->
+                query.isBlank() ||
+                    app.applicationName.contains(query, ignoreCase = true) ||
+                    app.packageName.value.contains(query, ignoreCase = true)
+            }
+
+            BrowseAppsState.Loaded(
+                query = query,
+                totalApps = bucketApps.size,
+                apps = filtered.toImmutableList(),
+            )
+        }
+    }
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseBuckets.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseBuckets.kt
@@ -1,0 +1,24 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.domain
+
+import sk.styk.martin.apkanalyzer.core.appindex.model.AppAttributeIndex
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+internal const val UNKNOWN_SIGNER_KEY = " unknown-signer"
+internal const val UNKNOWN_COUNTRY_KEY = " unknown-country"
+
+internal fun AppAttributeIndex.bucketsFor(dimension: BrowseDimension, subKey: String? = null): Map<String, List<PackageName>> = when (dimension) {
+    BrowseDimension.Permission -> permission
+
+    BrowseDimension.TargetSdk -> targetSdk.mapKeys { it.key.toString() }
+
+    BrowseDimension.MinSdk -> minSdk.mapKeys { it.key.toString() }
+
+    BrowseDimension.InstallSource -> installSource.mapKeys { it.key.name }
+
+    BrowseDimension.SigningCertificate -> when (subKey) {
+        CERTIFICATE_ORGANIZATION -> certificateOrganization.mapKeys { it.key ?: UNKNOWN_SIGNER_KEY }
+        CERTIFICATE_COUNTRY -> certificateCountry.mapKeys { it.key ?: UNKNOWN_COUNTRY_KEY }
+        else -> certificateFingerprint
+    }
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseDimensionLabeler.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseDimensionLabeler.kt
@@ -1,0 +1,77 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.domain
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import sk.styk.martin.apkanalyzer.core.apppermissions.PermissionLabelProvider
+import sk.styk.martin.apkanalyzer.core.apps.analysis.SdkVersionResolver
+import sk.styk.martin.apkanalyzer.core.common.model.AppSource
+import sk.styk.martin.apkanalyzer.feature.browse.impl.R
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+import java.util.Locale
+import javax.inject.Inject
+
+private const val FINGERPRINT_LABEL_BYTE_COUNT = 8
+
+internal class BrowseDimensionLabeler @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val permissionLabelProvider: PermissionLabelProvider,
+    private val sdkVersionResolver: SdkVersionResolver,
+) {
+
+    fun label(
+        dimension: BrowseDimension,
+        key: String,
+        subKey: String? = null,
+    ): String = when (dimension) {
+        BrowseDimension.Permission -> permissionLabelProvider.getLabel(key)
+
+        BrowseDimension.TargetSdk, BrowseDimension.MinSdk ->
+            sdkVersionResolver.resolveVersion(key.toIntOrNull()) ?: context.getString(R.string.browse_sdk_unknown, key)
+
+        BrowseDimension.InstallSource -> when (key) {
+            AppSource.GooglePlay.name -> context.getString(R.string.browse_source_google_play)
+            AppSource.SystemPreinstalled.name -> context.getString(R.string.browse_source_system)
+            else -> context.getString(R.string.browse_source_unknown)
+        }
+
+        BrowseDimension.SigningCertificate -> when (subKey) {
+            CERTIFICATE_ORGANIZATION -> key.takeUnless { it == UNKNOWN_SIGNER_KEY } ?: context.getString(R.string.browse_signer_unknown)
+
+            CERTIFICATE_COUNTRY ->
+                key.takeUnless { it == UNKNOWN_COUNTRY_KEY }?.let { countryLabel(it) } ?: context.getString(R.string.browse_country_unknown)
+
+            else -> formatFingerprint(key).splitToChunks(FINGERPRINT_LABEL_BYTE_COUNT)
+        }
+    }
+
+    fun rawIdentifier(
+        dimension: BrowseDimension,
+        key: String,
+        subKey: String? = null,
+    ): String? = when (dimension) {
+        BrowseDimension.Permission -> key
+
+        BrowseDimension.TargetSdk, BrowseDimension.MinSdk -> context.getString(R.string.browse_api_level, key)
+
+        BrowseDimension.InstallSource -> null
+
+        BrowseDimension.SigningCertificate -> when (subKey) {
+            CERTIFICATE_ORGANIZATION -> null
+            CERTIFICATE_COUNTRY -> key.takeUnless { it == UNKNOWN_COUNTRY_KEY }
+            else -> formatFingerprint(key)
+        }
+    }
+
+    private fun countryLabel(countryCode: String): String {
+        val displayName = runCatching { Locale.Builder().setRegion(countryCode).build().displayCountry }.getOrNull()
+        return displayName?.takeIf { it.isNotBlank() && !it.equals(countryCode, ignoreCase = true) } ?: countryCode
+    }
+}
+
+private fun formatFingerprint(hex: String): String = hex.uppercase().chunked(2).joinToString(":")
+
+private fun String.splitToChunks(byteCount: Int): String {
+    val bytes = split(":")
+    val shortened = bytes.take(byteCount).joinToString(":")
+    return if (bytes.size > byteCount) "$shortened…" else shortened
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseSubAttributes.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseSubAttributes.kt
@@ -1,0 +1,26 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.domain
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import sk.styk.martin.apkanalyzer.feature.browse.impl.R
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+internal const val CERTIFICATE_FINGERPRINT = "fingerprint"
+internal const val CERTIFICATE_ORGANIZATION = "organization"
+internal const val CERTIFICATE_COUNTRY = "country"
+
+internal data class BrowseSubAttribute(val key: String, val labelRes: Int)
+
+internal fun BrowseDimension.subAttributes(): ImmutableList<BrowseSubAttribute> = when (this) {
+    BrowseDimension.SigningCertificate -> persistentListOf(
+        BrowseSubAttribute(CERTIFICATE_FINGERPRINT, R.string.browse_certificate_attribute_fingerprint),
+        BrowseSubAttribute(CERTIFICATE_ORGANIZATION, R.string.browse_certificate_attribute_organization),
+        BrowseSubAttribute(CERTIFICATE_COUNTRY, R.string.browse_certificate_attribute_country),
+    )
+
+    BrowseDimension.Permission,
+    BrowseDimension.TargetSdk,
+    BrowseDimension.MinSdk,
+    BrowseDimension.InstallSource,
+    -> persistentListOf()
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/model/BrowseDimension.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/model/BrowseDimension.kt
@@ -1,0 +1,12 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal enum class BrowseDimension {
+    Permission,
+    SigningCertificate,
+    TargetSdk,
+    MinSdk,
+    InstallSource,
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/navigation/BrowseAppsNavKey.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/navigation/BrowseAppsNavKey.kt
@@ -1,0 +1,13 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.navigation
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+@Serializable
+internal data class BrowseAppsNavKey(
+    val dimension: BrowseDimension,
+    val bucketKey: String,
+    val bucketLabel: String,
+    val subAttribute: String?,
+) : NavKey

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/navigation/BrowseEntryProvider.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/navigation/BrowseEntryProvider.kt
@@ -2,11 +2,48 @@ package sk.styk.martin.apkanalyzer.feature.browse.impl.navigation
 
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
+import sk.styk.martin.apkanalyzer.core.navigation.Navigator
+import sk.styk.martin.apkanalyzer.core.uilibrary.animation.slideFromEndEntryMetadata
+import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
+import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailNavKey
 import sk.styk.martin.apkanalyzer.feature.browse.api.BrowseNavKey
 import sk.styk.martin.apkanalyzer.feature.browse.impl.BrowseScreen
+import sk.styk.martin.apkanalyzer.feature.browse.impl.apps.BrowseAppsScreen
+import sk.styk.martin.apkanalyzer.feature.browse.impl.options.BrowseOptionsScreen
 
-fun EntryProviderScope<NavKey>.browseEntries() {
+fun EntryProviderScope<NavKey>.browseEntries(navigator: Navigator) {
     entry<BrowseNavKey> {
-        BrowseScreen()
+        BrowseScreen(
+            onOpenDimension = { dimension ->
+                navigator.navigate(BrowseOptionsNavKey(dimension))
+            },
+        )
+    }
+
+    entry<BrowseOptionsNavKey>(
+        metadata = slideFromEndEntryMetadata(),
+    ) { key ->
+        BrowseOptionsScreen(
+            dimension = key.dimension,
+            onBack = { navigator.goBack() },
+            onOpenOption = { bucketKey, bucketLabel, subAttribute ->
+                navigator.navigate(BrowseAppsNavKey(key.dimension, bucketKey, bucketLabel, subAttribute))
+            },
+        )
+    }
+
+    entry<BrowseAppsNavKey>(
+        metadata = slideFromEndEntryMetadata(),
+    ) { key ->
+        BrowseAppsScreen(
+            dimension = key.dimension,
+            bucketKey = key.bucketKey,
+            bucketLabel = key.bucketLabel,
+            subAttribute = key.subAttribute,
+            onBack = { navigator.goBack() },
+            onOpenApp = { packageName ->
+                navigator.navigate(AppDetailNavKey(AppDetailInput.InstalledPackage(packageName.value)))
+            },
+        )
     }
 }

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/navigation/BrowseOptionsNavKey.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/navigation/BrowseOptionsNavKey.kt
@@ -1,0 +1,8 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.navigation
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+@Serializable
+internal data class BrowseOptionsNavKey(val dimension: BrowseDimension) : NavKey

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsAction.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsAction.kt
@@ -1,0 +1,7 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.options
+
+internal sealed interface BrowseOptionsAction {
+    data class ChangeQuery(val query: String) : BrowseOptionsAction
+    data class SelectSubAttribute(val key: String) : BrowseOptionsAction
+    data class SelectOption(val option: BrowseOption) : BrowseOptionsAction
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsEvent.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsEvent.kt
@@ -1,0 +1,9 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.options
+
+internal sealed interface BrowseOptionsEvent {
+    data class NavigateToApps(
+        val bucketKey: String,
+        val bucketLabel: String,
+        val subAttribute: String?,
+    ) : BrowseOptionsEvent
+}

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsScreen.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsScreen.kt
@@ -1,0 +1,317 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.options
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Icon
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.LoadingSpinner
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.SearchBarActive
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.SelectorChip
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Text
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Toolbar
+import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
+import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.collapsingHeader
+import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.collapsingHeaderContainer
+import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.rememberCollapsingHeaderState
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.Shapes
+import sk.styk.martin.apkanalyzer.feature.browse.impl.R
+import sk.styk.martin.apkanalyzer.feature.browse.impl.domain.subAttributes
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+import sk.styk.martin.apkanalyzer.feature.browse.impl.title
+
+@Composable
+internal fun BrowseOptionsScreen(
+    dimension: BrowseDimension,
+    onBack: () -> Unit,
+    onOpenOption: (bucketKey: String, bucketLabel: String, subAttribute: String?) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: BrowseOptionsViewModel = hiltViewModel { factory: BrowseOptionsViewModel.Factory -> factory.create(dimension) },
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is BrowseOptionsEvent.NavigateToApps -> onOpenOption(event.bucketKey, event.bucketLabel, event.subAttribute)
+            }
+        }
+    }
+
+    BrowseOptionsContent(
+        dimension = dimension,
+        state = state,
+        onAction = viewModel::onAction,
+        onBack = onBack,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun BrowseOptionsContent(
+    dimension: BrowseDimension,
+    state: BrowseOptionsState,
+    onAction: (BrowseOptionsAction) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(AppTheme.colors.background),
+    ) {
+        Toolbar(title = dimension.title(), onBack = onBack)
+
+        when (state) {
+            is BrowseOptionsState.Loading -> Box(modifier = Modifier.fillMaxSize()) {
+                LoadingSpinner(modifier = Modifier.align(Alignment.Center))
+            }
+
+            is BrowseOptionsState.Loaded -> BrowseOptionsList(
+                dimension = dimension,
+                showSearch = dimension != BrowseDimension.InstallSource,
+                state = state,
+                onAction = onAction,
+            )
+        }
+    }
+}
+
+@Composable
+private fun BrowseOptionsList(
+    dimension: BrowseDimension,
+    showSearch: Boolean,
+    state: BrowseOptionsState.Loaded,
+    onAction: (BrowseOptionsAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val collapsingState = rememberCollapsingHeaderState()
+    val subAttributes = dimension.subAttributes()
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .clipToBounds()
+            .collapsingHeaderContainer(collapsingState),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .offset { collapsingState.headerOffset }
+                .background(AppTheme.colors.background)
+                .collapsingHeader(collapsingState),
+        ) {
+            if (showSearch) {
+                SearchBarActive(
+                    query = state.query,
+                    placeholder = pluralStringResource(R.plurals.browse_options_filter_hint, state.totalOptions, state.totalOptions),
+                    onQueryChange = { onAction(BrowseOptionsAction.ChangeQuery(it)) },
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+            if (subAttributes.isNotEmpty()) {
+                val selected = subAttributes.firstOrNull { it.key == state.subAttribute } ?: subAttributes.first()
+                SelectorChip(
+                    sheetTitle = stringResource(R.string.browse_sub_attribute_sheet_title),
+                    options = subAttributes,
+                    selected = selected,
+                    label = { stringResource(it.labelRes) },
+                    onSelectOption = { onAction(BrowseOptionsAction.SelectSubAttribute(it.key)) },
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            }
+        }
+
+        if (state.options.isNotEmpty()) {
+            LazyColumn(
+                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .offset { collapsingState.contentOffset },
+            ) {
+                items(items = state.options, key = { it.key }) { option ->
+                    BrowseOptionRow(
+                        option = option,
+                        onClick = { onAction(BrowseOptionsAction.SelectOption(option)) },
+                    )
+                }
+            }
+        } else {
+            Text(
+                text = stringResource(R.string.browse_options_empty_query, state.query),
+                style = AppTheme.typography.bodyLarge,
+                color = AppTheme.colors.onBackground,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .offset { collapsingState.contentOffset }
+                    .padding(horizontal = 32.dp, vertical = 48.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BrowseOptionRow(
+    option: BrowseOption,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(Shapes.CardShape)
+            .background(AppTheme.colors.surface)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = option.label,
+                style = AppTheme.typography.titleSmall,
+                color = AppTheme.colors.onBackground,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (option.rawIdentifier != null) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = option.rawIdentifier,
+                    style = AppTheme.typography.bodySmall,
+                    color = AppTheme.colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.StartEllipsis,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = pluralStringResource(R.plurals.browse_apps_count, option.count, option.count),
+            style = AppTheme.typography.labelMedium,
+            color = AppTheme.colors.primary,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Icon(
+            imageVector = ApkAnalyzerIcons.ChevronRight,
+            tint = AppTheme.colors.onSurfaceVariant,
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BrowseOptionsLoadingPreview() {
+    ApkAnalyzerTheme {
+        BrowseOptionsContent(dimension = BrowseDimension.Permission, state = BrowseOptionsState.Loading, onAction = {}, onBack = {})
+    }
+}
+
+@Preview
+@Composable
+private fun BrowseOptionsLoadedPreview() {
+    ApkAnalyzerTheme {
+        BrowseOptionsContent(dimension = BrowseDimension.Permission, state = sampleLoadedState(), onAction = {}, onBack = {})
+    }
+}
+
+@Preview
+@Composable
+private fun BrowseOptionsCertificatePreview() {
+    ApkAnalyzerTheme {
+        BrowseOptionsContent(
+            dimension = BrowseDimension.SigningCertificate,
+            state = sampleLoadedState().copy(
+                subAttribute = "fingerprint",
+                options = persistentListOf(
+                    BrowseOption(key = "a1b2c3", label = "A1:B2:C3:D4:E5:F6:A7:B8…", rawIdentifier = "A1:B2:C3:D4:E5:F6:A7:B8:C9:D0", count = 12),
+                    BrowseOption(key = "f9e8d7", label = "F9:E8:D7:C6:B5:A4:93:82…", rawIdentifier = "F9:E8:D7:C6:B5:A4:93:82:71:60", count = 3),
+                ).toImmutableList(),
+            ),
+            onAction = {},
+            onBack = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BrowseOptionsNoSearchPreview() {
+    ApkAnalyzerTheme {
+        BrowseOptionsContent(
+            dimension = BrowseDimension.InstallSource,
+            state = sampleLoadedState().copy(
+                options = persistentListOf(
+                    BrowseOption(key = "GooglePlay", label = "Google Play", rawIdentifier = null, count = 150),
+                    BrowseOption(key = "SystemPreinstalled", label = "System", rawIdentifier = null, count = 30),
+                    BrowseOption(key = "Unknown", label = "Unknown", rawIdentifier = null, count = 7),
+                ).toImmutableList(),
+            ),
+            onAction = {},
+            onBack = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BrowseOptionsEmptyPreview() {
+    ApkAnalyzerTheme {
+        BrowseOptionsContent(
+            dimension = BrowseDimension.Permission,
+            state = sampleLoadedState().copy(query = "xyz", options = persistentListOf()),
+            onAction = {},
+            onBack = {},
+        )
+    }
+}
+
+private fun sampleLoadedState() = BrowseOptionsState.Loaded(
+    query = "",
+    subAttribute = null,
+    totalOptions = 3,
+    options = persistentListOf(
+        BrowseOption(key = "android.permission.INTERNET", label = "Full network access", rawIdentifier = "android.permission.INTERNET", count = 176),
+        BrowseOption(key = "android.permission.CAMERA", label = "Camera", rawIdentifier = "android.permission.CAMERA", count = 24),
+        BrowseOption(
+            key = "android.permission.ACCESS_FINE_LOCATION",
+            label = "Precise location",
+            rawIdentifier = "android.permission.ACCESS_FINE_LOCATION",
+            count = 18,
+        ),
+    ).toImmutableList(),
+)

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsState.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsState.kt
@@ -1,0 +1,26 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.options
+
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+
+@Immutable
+internal sealed interface BrowseOptionsState {
+
+    data object Loading : BrowseOptionsState
+
+    @Immutable
+    data class Loaded(
+        val query: String,
+        val subAttribute: String?,
+        val totalOptions: Int,
+        val options: ImmutableList<BrowseOption>,
+    ) : BrowseOptionsState
+}
+
+@Immutable
+internal data class BrowseOption(
+    val key: String,
+    val label: String,
+    val rawIdentifier: String?,
+    val count: Int,
+)

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsViewModel.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsViewModel.kt
@@ -1,0 +1,124 @@
+package sk.styk.martin.apkanalyzer.feature.browse.impl.options
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import sk.styk.martin.apkanalyzer.core.appindex.AppIndexRepository
+import sk.styk.martin.apkanalyzer.core.appindex.model.AppAttributeIndex
+import sk.styk.martin.apkanalyzer.core.appindex.model.AppIndexStatus
+import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.feature.browse.impl.domain.BrowseDimensionLabeler
+import sk.styk.martin.apkanalyzer.feature.browse.impl.domain.bucketsFor
+import sk.styk.martin.apkanalyzer.feature.browse.impl.domain.subAttributes
+import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
+
+@HiltViewModel(assistedFactory = BrowseOptionsViewModel.Factory::class)
+internal class BrowseOptionsViewModel @AssistedInject constructor(
+    @Assisted private val dimension: BrowseDimension,
+    appIndexRepository: AppIndexRepository,
+    private val labeler: BrowseDimensionLabeler,
+    dispatcherProvider: DispatcherProvider,
+) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(dimension: BrowseDimension): BrowseOptionsViewModel
+    }
+
+    private val subAttributeKeys = dimension.subAttributes().map { it.key }.ifEmpty { listOf(null) }
+
+    private val narrowing = MutableStateFlow(Narrowing())
+
+    private val source = appIndexRepository.index()
+        .map { it.toSource() }
+        .flowOn(dispatcherProvider.io())
+
+    val state: StateFlow<BrowseOptionsState> = combine(source, narrowing) { source, narrowing ->
+        when (source) {
+            OptionsSource.Loading -> BrowseOptionsState.Loading
+            is OptionsSource.Ready -> source.narrowedBy(narrowing)
+        }
+    }
+        .flowOn(dispatcherProvider.default())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), BrowseOptionsState.Loading)
+
+    private val eventChannel = Channel<BrowseOptionsEvent>(Channel.BUFFERED)
+    val events = eventChannel.receiveAsFlow()
+
+    fun onAction(action: BrowseOptionsAction) {
+        when (action) {
+            is BrowseOptionsAction.ChangeQuery -> narrowing.update { it.copy(query = action.query) }
+
+            is BrowseOptionsAction.SelectSubAttribute -> narrowing.update { it.copy(subAttribute = action.key) }
+
+            is BrowseOptionsAction.SelectOption -> {
+                val loaded = state.value as? BrowseOptionsState.Loaded
+                eventChannel.trySend(
+                    BrowseOptionsEvent.NavigateToApps(
+                        bucketKey = action.option.key,
+                        bucketLabel = action.option.label,
+                        subAttribute = loaded?.subAttribute,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun AppIndexStatus.toSource(): OptionsSource = when (this) {
+        AppIndexStatus.Loading -> OptionsSource.Loading
+
+        is AppIndexStatus.Data -> OptionsSource.Ready(
+            optionsBySubAttribute = subAttributeKeys.associateWith { key -> index.buildOptions(key) },
+        )
+    }
+
+    private fun AppAttributeIndex.buildOptions(subKey: String?): List<BrowseOption> = bucketsFor(dimension, subKey)
+        .map { (key, packages) ->
+            BrowseOption(
+                key = key,
+                label = labeler.label(dimension, key, subKey),
+                rawIdentifier = labeler.rawIdentifier(dimension, key, subKey),
+                count = packages.size,
+            )
+        }
+        .sortedWith(compareByDescending<BrowseOption> { it.count }.thenBy { it.label })
+}
+
+private data class Narrowing(val query: String = "", val subAttribute: String? = null)
+
+private sealed interface OptionsSource {
+    data object Loading : OptionsSource
+
+    data class Ready(val optionsBySubAttribute: Map<String?, List<BrowseOption>>) : OptionsSource
+}
+
+private fun OptionsSource.Ready.narrowedBy(narrowing: Narrowing): BrowseOptionsState.Loaded {
+    val effectiveSubAttribute = narrowing.subAttribute?.takeIf { it in optionsBySubAttribute } ?: optionsBySubAttribute.keys.firstOrNull()
+    val allOptions = optionsBySubAttribute[effectiveSubAttribute].orEmpty()
+    val filtered = allOptions.filter { it.matches(narrowing.query) }
+
+    return BrowseOptionsState.Loaded(
+        query = narrowing.query,
+        subAttribute = effectiveSubAttribute,
+        totalOptions = allOptions.size,
+        options = filtered.toImmutableList(),
+    )
+}
+
+private fun BrowseOption.matches(query: String): Boolean = query.isBlank() ||
+    label.contains(query, ignoreCase = true) ||
+    rawIdentifier?.contains(query, ignoreCase = true) == true

--- a/feature/browse/impl/src/main/res/values/strings.xml
+++ b/feature/browse/impl/src/main/res/values/strings.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browse_title">Browse</string>
+    <string name="browse_subtitle_loading">Scanning installed apps…</string>
+    <plurals name="browse_subtitle">
+        <item quantity="one">Explore %1$d app installed on this device</item>
+        <item quantity="other">Explore %1$d apps installed on this device</item>
+    </plurals>
+
+    <string name="browse_dimension_permission_title">Permissions</string>
+    <string name="browse_dimension_permission_subtitle">See which apps use a given permission</string>
+    <string name="browse_dimension_certificate_title">Signing certificate</string>
+    <string name="browse_dimension_certificate_subtitle">Group apps by signer identity, publisher name, or country</string>
+    <string name="browse_dimension_target_sdk_title">Target Android version</string>
+    <string name="browse_dimension_target_sdk_subtitle">See which Android version each app was built for</string>
+    <string name="browse_dimension_min_sdk_title">Minimum Android version</string>
+    <string name="browse_dimension_min_sdk_subtitle">See the oldest Android version each app still supports</string>
+    <string name="browse_dimension_install_source_title">Install source</string>
+    <string name="browse_dimension_install_source_subtitle">See where each app came from</string>
+    <plurals name="browse_dimension_option_count">
+        <item quantity="one">%1$d option</item>
+        <item quantity="other">%1$d options</item>
+    </plurals>
+
+    <string name="browse_sdk_unknown">API level %1$s</string>
+    <string name="browse_api_level">API %1$s</string>
+    <string name="browse_source_google_play">Google Play</string>
+    <string name="browse_source_system">System</string>
+    <string name="browse_source_unknown">Unknown</string>
+    <string name="browse_signer_unknown">Unknown signer</string>
+    <string name="browse_country_unknown">Unknown country</string>
+
+    <string name="browse_sub_attribute_sheet_title">Group by</string>
+    <string name="browse_certificate_attribute_fingerprint">Identity (SHA-256)</string>
+    <string name="browse_certificate_attribute_organization">Publisher name</string>
+    <string name="browse_certificate_attribute_country">Country</string>
+
+    <plurals name="browse_options_filter_hint">
+        <item quantity="one">Filter %1$d option</item>
+        <item quantity="other">Filter %1$d options</item>
+    </plurals>
+    <string name="browse_options_empty_query">No options match “%1$s”</string>
+    <plurals name="browse_apps_count">
+        <item quantity="one">%1$d app</item>
+        <item quantity="other">%1$d apps</item>
+    </plurals>
+
+    <plurals name="browse_apps_filter_hint">
+        <item quantity="one">Filter %1$d app</item>
+        <item quantity="other">Filter %1$d apps</item>
+    </plurals>
+    <string name="browse_apps_empty_query">No apps match “%1$s”</string>
+</resources>


### PR DESCRIPTION
## Summary
- Implements the free-tier "Browse by Attribute" screen: hub (dimension cards) → options (bucket list with counts) → apps (apps in a tapped bucket) → `feature:app-detail`, all sourced from `core:app-index`'s already-shipped `AppIndexRepository`.
- Signing certificate supports grouping by fingerprint (default), publisher name, or country through a generic per-dimension sub-attribute mechanism (`BrowseDimension.subAttributes()`), so a future dimension needing the same picker doesn't require new NavKey/ViewModel/Screen plumbing — only a `domain/` addition.
- Marks `CE-01`, `CE-05`, `FR-08`, `FR-09`, `FR-40`, `FR-41` Done in `docs/product/roadmap.md`.

## Test plan
- [x] `./gradlew spotlessCheck detektDebug :build-logic:convention:detektMain lintDebug :app:assembleDebug validateAgentContext` — all green
- [x] Verified on-device (OnePlus 8T, Android 14): hub loads real device data, dimension cards render with fixed (non-scrolling, non-wrapping) preview chips and chevrons aligned to the title row, options screen search/sort/sub-attribute switching all work, Country/Organization/Fingerprint grouping produces correct distinct buckets, tapping an app opens the real `feature:app-detail` hub
- [x] Fixed during review: Options → Apps navigation losing the selected sub-attribute (was always looking up the Fingerprint-keyed bucket regardless of what was selected, causing "no apps match" for Organization/Country buckets)
- [x] Fixed during review: hub's per-dimension label-resolution work re-running on every search keystroke instead of only when the index changes

https://claude.ai/code/session_0152Cb6cgHdoRVDfkxLCjyjb