### PR TITLE
Tighten Detekt rule enforcement

### DIFF
--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/ValidateAgentContextTask.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/ValidateAgentContextTask.kt
@@ -10,6 +10,8 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
 
+private val nonLocalLinkPrefixes = listOf("http://", "https://", "mailto:", "#")
+
 @DisableCachingByDefault(because = "The task validates the live repository context without producing outputs.")
 abstract class ValidateAgentContextTask : DefaultTask() {
 
@@ -60,18 +62,12 @@ abstract class ValidateAgentContextTask : DefaultTask() {
 
         val normalizedRoot = rootDirectory.toPath().toAbsolutePath().normalize()
         modules.get().forEach { (modulePath, relativeModuleDirectory) ->
-            var directory = rootDirectory.resolve(relativeModuleDirectory)
-            var closestAgentFile: File? = null
-
-            while (directory.toPath().toAbsolutePath().normalize().startsWith(normalizedRoot)) {
-                val candidate = directory.resolve("AGENTS.md")
-                if (candidate.isFile) {
-                    closestAgentFile = candidate
-                    break
-                }
-                if (directory == rootDirectory) break
-                directory = directory.parentFile
+            val closestAgentFile = generateSequence(rootDirectory.resolve(relativeModuleDirectory)) { directory ->
+                directory.parentFile.takeIf { directory != rootDirectory }
             }
+                .takeWhile { directory -> directory.toPath().toAbsolutePath().normalize().startsWith(normalizedRoot) }
+                .map { directory -> directory.resolve("AGENTS.md") }
+                .firstOrNull(File::isFile)
 
             if (closestAgentFile == null || closestAgentFile == rootDirectory.resolve("AGENTS.md")) {
                 errors += "$modulePath has no module-scoped AGENTS.md."
@@ -91,38 +87,37 @@ abstract class ValidateAgentContextTask : DefaultTask() {
             option = RegexOption.DOT_MATCHES_ALL,
         )
 
-        for (skillDirectory in skillDirectories) {
+        skillDirectories.forEach { skillDirectory ->
             val skillFile = skillDirectory.resolve("SKILL.md")
             if (!skillFile.isFile) {
                 errors += "Missing ${skillFile.displayPath()}."
-                continue
-            }
-            skillFiles += skillFile
+            } else {
+                skillFiles += skillFile
 
-            val frontmatter = frontmatterPattern.find(skillFile.readText())?.groupValues?.get(1)
-            if (frontmatter == null) {
-                errors += "${skillFile.displayPath()} has invalid YAML frontmatter."
-                continue
-            }
+                val frontmatter = frontmatterPattern.find(skillFile.readText())?.groupValues?.get(1)
+                if (frontmatter == null) {
+                    errors += "${skillFile.displayPath()} has invalid YAML frontmatter."
+                } else {
+                    fun metadataValue(key: String): String? = Regex("""(?m)^$key:\s*(.+?)\s*$""")
+                        .find(frontmatter)
+                        ?.groupValues
+                        ?.get(1)
+                        ?.trim()
+                        ?.trim('"', '\'')
 
-            fun metadataValue(key: String): String? = Regex("""(?m)^$key:\s*(.+?)\s*$""")
-                .find(frontmatter)
-                ?.groupValues
-                ?.get(1)
-                ?.trim()
-                ?.trim('"', '\'')
+                    val name = metadataValue("name")
+                    val description = metadataValue("description")
 
-            val name = metadataValue("name")
-            val description = metadataValue("description")
-
-            if (name != skillDirectory.name) {
-                errors += "${skillFile.displayPath()} name must match directory ${skillDirectory.name}."
-            }
-            if (name == null || !skillNamePattern.matches(name)) {
-                errors += "${skillFile.displayPath()} has an invalid skill name."
-            }
-            if (description.isNullOrBlank() || description.length > 1024) {
-                errors += "${skillFile.displayPath()} needs a description of 1 to 1024 characters."
+                    if (name != skillDirectory.name) {
+                        errors += "${skillFile.displayPath()} name must match directory ${skillDirectory.name}."
+                    }
+                    if (name == null || !skillNamePattern.matches(name)) {
+                        errors += "${skillFile.displayPath()} has an invalid skill name."
+                    }
+                    if (description.isNullOrBlank() || description.length > 1024) {
+                        errors += "${skillFile.displayPath()} needs a description of 1 to 1024 characters."
+                    }
+                }
             }
         }
 
@@ -168,12 +163,7 @@ abstract class ValidateAgentContextTask : DefaultTask() {
         contextFiles.forEach { contextFile ->
             for (match in markdownLinkPattern.findAll(contextFile.readText())) {
                 val target = match.groupValues[1]
-                if (
-                    target.startsWith("http://") ||
-                    target.startsWith("https://") ||
-                    target.startsWith("mailto:") ||
-                    target.startsWith("#")
-                ) {
+                if (nonLocalLinkPrefixes.any(target::startsWith)) {
                     continue
                 }
 

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -7,8 +7,12 @@ comments:
 
 complexity:
   severity: warning
+  ComplexCondition:
+    severity: error
   CyclomaticComplexMethod:
     allowedComplexity: 15
+  NestedBlockDepth:
+    severity: error
   TooManyFunctions:
     active: false
 
@@ -24,8 +28,6 @@ coroutines:
     active: true
 
 exceptions:
-  TooGenericExceptionCaught:
-    severity: warning
   TooGenericExceptionThrown:
     severity: warning
   ErrorUsageWithThrowable:
@@ -54,8 +56,6 @@ potential-bugs:
     active: true
 
 style:
-  LoopWithTooManyJumpStatements:
-    severity: warning
   MagicNumber:
     active: false
   MaxLineLength:

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/ManifestParserImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/ManifestParserImpl.kt
@@ -71,14 +71,8 @@ internal class ManifestParserImpl @Inject constructor(private val packageManager
         val manifests = mutableMapOf<String, ParsedComponentManifest>()
 
         for (cookie in 1..MAX_ASSET_COOKIE) {
-            val parsedManifest = try {
-                resources.assets.openXmlResourceParser(cookie, MANIFEST_FILE_NAME).use { parser ->
-                    readComponentManifest(parser, resources)
-                }
-            } catch (_: FileNotFoundException) {
-                continue
-            }
-            if (parsedManifest.packageName == packageName.value) {
+            val parsedManifest = readInstalledComponentManifest(resources, cookie)
+            if (parsedManifest?.packageName == packageName.value) {
                 manifests.putIfAbsent(parsedManifest.splitName.orEmpty(), parsedManifest)
                 if (manifests.size == expectedManifestCount) break
             }
@@ -88,6 +82,14 @@ internal class ManifestParserImpl @Inject constructor(private val packageManager
             "Read ${manifests.size} of $expectedManifestCount installed manifests for $packageName"
         }
         return manifests.values.flatMap { it.filters }
+    }
+
+    private fun readInstalledComponentManifest(resources: Resources, cookie: Int): ParsedComponentManifest? = try {
+        resources.assets.openXmlResourceParser(cookie, MANIFEST_FILE_NAME).use { parser ->
+            readComponentManifest(parser, resources)
+        }
+    } catch (_: FileNotFoundException) {
+        null
     }
 
     private fun resourcesForApk(apkPath: String): Resources {
@@ -162,20 +164,11 @@ internal class ManifestParserImpl @Inject constructor(private val packageManager
                     CATEGORY_TAG -> parser.resolvedAndroidString(resources, NAME_ATTRIBUTE)?.let { currentFilter?.categories?.add(it) }
 
                     DATA_TAG -> currentFilter?.let { filter ->
-                        val rules = currentUriRelativeGroup?.dataRules ?: filter.dataRules
-                        val host = parser.resolvedAndroidString(resources, IntentFilterDataRuleType.Host.manifestAttribute)
-                        val port = parser.resolvedAndroidString(resources, IntentFilterDataRuleType.Port.manifestAttribute)
-                        if (host != null) {
-                            val authority = if (port != null) "$host:$port" else host
-                            rules.add(IntentFilterDataRule(type = IntentFilterDataRuleType.Host, value = authority))
-                        }
-                        IntentFilterDataRuleType.entries
-                            .filterNot { it == IntentFilterDataRuleType.Host || it == IntentFilterDataRuleType.Port }
-                            .forEach { type ->
-                                parser.resolvedAndroidString(resources, type.manifestAttribute)?.let { value ->
-                                    rules.add(IntentFilterDataRule(type = type, value = value))
-                                }
-                            }
+                        addIntentFilterDataRules(
+                            parser = parser,
+                            resources = resources,
+                            rules = currentUriRelativeGroup?.dataRules ?: filter.dataRules,
+                        )
                     }
                 }
 
@@ -200,6 +193,26 @@ internal class ManifestParserImpl @Inject constructor(private val packageManager
             eventType = parser.next()
         }
         return ParsedComponentManifest(packageName = packageName, splitName = splitName, filters = filters)
+    }
+
+    private fun addIntentFilterDataRules(
+        parser: XmlResourceParser,
+        resources: Resources,
+        rules: MutableList<IntentFilterDataRule>,
+    ) {
+        val host = parser.resolvedAndroidString(resources, IntentFilterDataRuleType.Host.manifestAttribute)
+        val port = parser.resolvedAndroidString(resources, IntentFilterDataRuleType.Port.manifestAttribute)
+        if (host != null) {
+            val authority = if (port != null) "$host:$port" else host
+            rules.add(IntentFilterDataRule(type = IntentFilterDataRuleType.Host, value = authority))
+        }
+        IntentFilterDataRuleType.entries
+            .filterNot { it == IntentFilterDataRuleType.Host || it == IntentFilterDataRuleType.Port }
+            .forEach { type ->
+                parser.resolvedAndroidString(resources, type.manifestAttribute)?.let { value ->
+                    rules.add(IntentFilterDataRule(type = type, value = value))
+                }
+            }
     }
 
     private fun appendStartTag(

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/util/AppOperations.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/util/AppOperations.kt
@@ -19,7 +19,9 @@ fun Context.openAppSystemPage(packageName: PackageName) {
                 data = "package:$packageName".toUri()
             },
         )
-    } catch (e: Exception) {
+    } catch (e: ActivityNotFoundException) {
+        Logger.e(TAG, e, "Could not open system page for $packageName")
+    } catch (e: SecurityException) {
         Logger.e(TAG, e, "Could not open system page for $packageName")
     }
 }

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentsScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentsScreen.kt
@@ -317,7 +317,8 @@ private fun ComponentRow(
                     overflow = TextOverflow.StartEllipsis,
                 )
             }
-            if (item.isUnprotected || item.isLauncher || item.isExported || item.flags.isNotEmpty()) {
+            val hasStatusTag = item.isUnprotected || item.isLauncher || item.isExported
+            if (hasStatusTag || item.flags.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(6.dp))
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFiltersScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFiltersScreen.kt
@@ -204,6 +204,9 @@ private fun IntentFilterRow(
         .filterNot { it == Intent.CATEGORY_DEFAULT }
         .map { it.toDisplayCategory() }
         .filter { it.isNotBlank() }
+    val hasBlockedRules = filter.uriRelativeGroups.any { !it.isAllowed }
+    val hasRequestBadges = actionBadges.isNotEmpty() || categoryBadges.isNotEmpty()
+    val hasFilterBadges = filter.isAutoVerify || hasBlockedRules
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -242,12 +245,7 @@ private fun IntentFilterRow(
             label = stringResource(R.string.components_intent_data_mime_type),
             values = dataRules.valuesFor(IntentFilterDataRuleType.MimeType),
         )
-        if (
-            actionBadges.isNotEmpty() ||
-            categoryBadges.isNotEmpty() ||
-            filter.isAutoVerify ||
-            filter.uriRelativeGroups.any { !it.isAllowed }
-        ) {
+        if (hasRequestBadges || hasFilterBadges) {
             Spacer(modifier = Modifier.height(12.dp))
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -262,7 +260,7 @@ private fun IntentFilterRow(
                 if (filter.isAutoVerify) {
                     IntentFilterTag(text = stringResource(R.string.intent_filters_tag_verified))
                 }
-                if (filter.uriRelativeGroups.any { !it.isAllowed }) {
+                if (hasBlockedRules) {
                     IntentFilterTag(text = stringResource(R.string.intent_filters_tag_blocked_rules))
                 }
             }


### PR DESCRIPTION
## Summary
- migrate `TooGenericExceptionCaught`, `NestedBlockDepth`, `ComplexCondition`, and `LoopWithTooManyJumpStatements` from warning-only rollout status to strict enforcement
- refactor Android manifest parsing and agent-context validation to remove the affected findings
- name UI predicates for component status and intent-filter badge visibility

## Remaining migration backlog
- `LongMethod`: 35
- `LongParameterList`: 28
- `CyclomaticComplexMethod`: 13
- `ReturnCount`: 7

No Detekt baseline is used.