### PR TITLE
Clear Detekt ReturnCount findings

### DIFF
--- a/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/externalapk/ExternalApkActivity.kt
+++ b/app/src/main/kotlin/sk/styk/martin/apkanalyzer/ui/externalapk/ExternalApkActivity.kt
@@ -39,7 +39,7 @@ class ExternalApkActivity : ComponentActivity() {
     }
 }
 
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION", "ReturnCount")
 private fun Intent.externalApkUri(): String? {
     if (action != Intent.ACTION_VIEW && action != Intent.ACTION_INSTALL_PACKAGE) return null
     val uri = data ?: return null

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/StorageStatsRepositoryImpl.kt
@@ -63,10 +63,10 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun queryTotalSize(packageName: PackageName): AppSize? {
-        totalSizes.value[packageName]?.let { return it }
-        if (!checkPermission()) return null
-        return queryPackageSize(UserHandle.getUserHandleForUid(Process.myUid()), packageName)
+    override suspend fun queryTotalSize(packageName: PackageName): AppSize? = totalSizes.value[packageName] ?: if (checkPermission()) {
+        queryPackageSize(UserHandle.getUserHandleForUid(Process.myUid()), packageName)
+    } else {
+        null
     }
 
     private fun fetchTotalSizes(packageNames: List<PackageName>) {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/UsageStatsRepositoryImpl.kt
@@ -43,13 +43,13 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun queryLastUsedTime(packageName: PackageName): Instant? {
-        lastUsedTimes.value[packageName]?.let { return it }
-        if (!checkPermission()) return null
-        return queryRawUsageStats()
+    override suspend fun queryLastUsedTime(packageName: PackageName): Instant? = lastUsedTimes.value[packageName] ?: if (checkPermission()) {
+        queryRawUsageStats()
             .filter { it.packageName == packageName.value }
             .maxOfOrNull { it.lastTimeUsed }
             ?.let { Instant.ofEpochMilli(it) }
+    } else {
+        null
     }
 
     private fun fetchUsageTimes() {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/DeviceFeatures.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/DeviceFeatures.kt
@@ -9,13 +9,13 @@ data class DeviceFeatures(val featureVersions: Map<String, Int>, val openGlEsVer
 
     fun versionOf(featureName: String): Int? = featureVersions[featureName]
 
-    fun availabilityOf(feature: Feature): FeatureAvailability {
-        if (!isKnown) return FeatureAvailability.Unknown
-        return when (feature) {
-            is Feature.Hardware -> {
-                val deviceVersion = featureVersions[feature.name] ?: return FeatureAvailability.Missing
-                availabilityOf(required = feature.version, onDevice = deviceVersion)
-            }
+    fun availabilityOf(feature: Feature): FeatureAvailability = if (!isKnown) {
+        FeatureAvailability.Unknown
+    } else {
+        when (feature) {
+            is Feature.Hardware -> featureVersions[feature.name]
+                ?.let { availabilityOf(required = feature.version, onDevice = it) }
+                ?: FeatureAvailability.Missing
 
             is Feature.OpenGlEs -> when (openGlEsVersion) {
                 null -> FeatureAvailability.Unknown

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/search/domain/SearchAppsUseCase.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/search/domain/SearchAppsUseCase.kt
@@ -26,18 +26,19 @@ class SearchAppsUseCase @Inject constructor() {
         return min(nameScore, packageScore)
     }
 
-    private fun scoreField(query: String, field: String): Float {
-        if (field.contains(query)) return SCORE_EXACT_CONTAINS
+    private fun scoreField(query: String, field: String): Float = when {
+        field.contains(query) -> SCORE_EXACT_CONTAINS
 
-        if (field.split('.', ' ', '-', '_').any { it.startsWith(query) }) {
-            return SCORE_WORD_PREFIX
+        field.split('.', ' ', '-', '_').any { it.startsWith(query) } -> SCORE_WORD_PREFIX
+
+        else -> {
+            val minWindowDistance = slidingWindowDistance(query, field)
+            val normalized = minWindowDistance.toFloat() / query.length
+            SCORE_FUZZY_BASE + normalized
         }
-
-        val minWindowDistance = slidingWindowDistance(query, field)
-        val normalized = minWindowDistance.toFloat() / query.length
-        return SCORE_FUZZY_BASE + normalized
     }
 
+    @Suppress("ReturnCount")
     private fun slidingWindowDistance(query: String, text: String): Int {
         if (query.length > text.length) return levenshtein(query, text)
 
@@ -62,6 +63,7 @@ class SearchAppsUseCase @Inject constructor() {
     }
 }
 
+@Suppress("ReturnCount")
 internal fun levenshtein(a: String, b: String): Int {
     val m = a.length
     val n = b.length


### PR DESCRIPTION
## Summary
- Clear all seven Detekt `ReturnCount` findings without changing behavior.
- Refactor four findings into expression-based control flow.
- Keep three intentional early-return paths with narrow function-level suppressions.

## Validation
- `.\gradlew.bat spotlessApply --console=plain`
- `.\gradlew.bat :app:compileDebugKotlin :core:apps:compileDebugKotlin :feature:apps:impl:compileDebugKotlin --console=plain`
- `.\gradlew.bat detektDebug :build-logic:convention:detektMain --continue --console=plain` (zero `ReturnCount` findings)

## Suppression rationale
- `Intent.externalApkUri`: linear early returns clearly reject unsupported intent actions and missing platform URI data before scheme validation.
- `slidingWindowDistance`: the early fallback for an overlong query and immediate exit on an exact match avoid unnecessary search work and mutable control flags.
- `levenshtein`: empty-string base cases are clearer before allocating and traversing the distance rows.