### PR TITLE
Clear LongParameterList findings

### DIFF
--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -46,7 +46,10 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-internal class AppDetailRepositoryImpl @Inject constructor(
+internal class AppDetailRepositoryImpl
+@Suppress("LongParameterList")
+@Inject
+constructor(
     private val packageManager: PackageManager,
     private val sdkVersionResolver: SdkVersionResolver,
     private val installSourceResolver: InstallSourceResolver,
@@ -91,12 +94,14 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             val packageInfo = packageManager.getPackageInfo(packageName.value, analysisFlags)
             val intentFilters = manifestParser.componentIntentFilters(reference)
             getPackageDetails(
-                analysisMode = AppDetail.AnalysisMode.InstalledPackage,
-                packageInfo = packageInfo,
-                intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
-                areIntentFiltersAvailable = intentFilters.isSuccess,
-                totalSize = storageStatsRepository.queryTotalSize(packageName),
-                lastUsedTime = usageStatsRepository.queryLastUsedTime(packageName),
+                PackageDetailsInput(
+                    analysisMode = AppDetail.AnalysisMode.InstalledPackage,
+                    packageInfo = packageInfo,
+                    intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
+                    areIntentFiltersAvailable = intentFilters.isSuccess,
+                    totalSize = storageStatsRepository.queryTotalSize(packageName),
+                    lastUsedTime = usageStatsRepository.queryLastUsedTime(packageName),
+                ),
             )
         }.onSuccess { cache[packageName] = it }
     }
@@ -105,40 +110,37 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         val reference = AppReference.ApkFile(accessibleFile.absolutePath)
         val intentFilters = manifestParser.componentIntentFilters(reference)
         getPackageDetails(
-            analysisMode = AppDetail.AnalysisMode.ApkFile,
-            packageInfo = packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
-                ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}"),
-            intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
-            areIntentFiltersAvailable = intentFilters.isSuccess,
+            PackageDetailsInput(
+                analysisMode = AppDetail.AnalysisMode.ApkFile,
+                packageInfo = packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
+                    ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}"),
+                intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
+                areIntentFiltersAvailable = intentFilters.isSuccess,
+            ),
         )
     }
 
-    private fun getPackageDetails(
-        analysisMode: AppDetail.AnalysisMode,
-        packageInfo: PackageInfo,
-        intentFiltersByComponent: Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>,
-        areIntentFiltersAvailable: Boolean,
-        totalSize: AppSize? = null,
-        lastUsedTime: Instant? = null,
-    ) = AppDetail(
-        analysisMode = analysisMode,
-        info = getGeneralData(packageInfo, totalSize, lastUsedTime),
-        signing = certificateExtractor.getAppSigning(packageInfo),
-        activities = getActivities(
-            packageInfo = packageInfo,
-            launcherActivityNames = when (analysisMode) {
-                AppDetail.AnalysisMode.InstalledPackage -> queryLauncherActivityNames(PackageName(packageInfo.packageName))
-                AppDetail.AnalysisMode.ApkFile -> null
-            },
-            intentFiltersByComponent = intentFiltersByComponent,
-        ),
-        services = getServices(packageInfo, intentFiltersByComponent),
-        contentProviders = getContentProviders(packageInfo, intentFiltersByComponent),
-        receivers = getBroadcastReceivers(packageInfo, intentFiltersByComponent),
-        permissions = getPermissions(packageInfo),
-        features = getFeatures(packageInfo),
-        areComponentIntentFiltersAvailable = areIntentFiltersAvailable,
-    )
+    private fun getPackageDetails(input: PackageDetailsInput) = with(input) {
+        AppDetail(
+            analysisMode = analysisMode,
+            info = getGeneralData(packageInfo, totalSize, lastUsedTime),
+            signing = certificateExtractor.getAppSigning(packageInfo),
+            activities = getActivities(
+                packageInfo = packageInfo,
+                launcherActivityNames = when (analysisMode) {
+                    AppDetail.AnalysisMode.InstalledPackage -> queryLauncherActivityNames(PackageName(packageInfo.packageName))
+                    AppDetail.AnalysisMode.ApkFile -> null
+                },
+                intentFiltersByComponent = intentFiltersByComponent,
+            ),
+            services = getServices(packageInfo, intentFiltersByComponent),
+            contentProviders = getContentProviders(packageInfo, intentFiltersByComponent),
+            receivers = getBroadcastReceivers(packageInfo, intentFiltersByComponent),
+            permissions = getPermissions(packageInfo),
+            features = getFeatures(packageInfo),
+            areComponentIntentFiltersAvailable = areIntentFiltersAvailable,
+        )
+    }
 
     private fun getGeneralData(
         packageInfo: PackageInfo,
@@ -176,6 +178,15 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             lastUsedTime = lastUsedTime,
         )
     }
+
+    private data class PackageDetailsInput(
+        val analysisMode: AppDetail.AnalysisMode,
+        val packageInfo: PackageInfo,
+        val intentFiltersByComponent: Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>,
+        val areIntentFiltersAvailable: Boolean,
+        val totalSize: AppSize? = null,
+        val lastUsedTime: Instant? = null,
+    )
 
     private fun getActivities(
         packageInfo: PackageInfo,

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -24,7 +24,10 @@ import javax.inject.Inject
 
 internal const val INSTALLED_APPS = "InstalledApps"
 
-internal class InstalledAppsRepositoryImpl @Inject constructor(
+internal class InstalledAppsRepositoryImpl
+@Suppress("LongParameterList")
+@Inject
+constructor(
     private val packageManager: PackageManager,
     private val installSourceResolver: InstallSourceResolver,
     private val packageChangesObserver: PackageChangesObserver,

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/coroutines/Flows.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/coroutines/Flows.kt
@@ -3,6 +3,7 @@ package sk.styk.martin.apkanalyzer.core.common.coroutines
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 
+@Suppress("LongParameterList")
 fun <T1, T2, T3, T4, T5, T6, R> combine(
     flow: Flow<T1>,
     flow2: Flow<T2>,

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/Chip.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/Chip.kt
@@ -33,6 +33,7 @@ sealed interface ChipVariant {
     data object Negative : ChipVariant
 }
 
+@Suppress("LongParameterList")
 @Composable
 fun Chip(
     label: String,
@@ -106,6 +107,7 @@ fun Chip(
     }
 }
 
+@Suppress("LongParameterList")
 @Composable
 fun Chip(
     label: String,
@@ -184,6 +186,7 @@ private fun ChipVariant.colors() = when (this) {
     ChipVariant.Negative -> AppTheme.colors.negativeContainer to AppTheme.colors.negative
 }
 
+@Suppress("LongParameterList")
 @Composable
 fun OutlinedChip(
     label: String,

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/IconButton.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/IconButton.kt
@@ -25,6 +25,7 @@ enum class IconButtonStyle {
     Highlighted,
 }
 
+@Suppress("LongParameterList")
 @Composable
 fun IconButton(
     imageVector: ImageVector,

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/MultiSelectorChip.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/MultiSelectorChip.kt
@@ -26,6 +26,7 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
 
+@Suppress("LongParameterList")
 @Composable
 fun <T> MultiSelectorChip(
     sheetTitle: String,

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/SelectorChip.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/SelectorChip.kt
@@ -25,6 +25,7 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
 
+@Suppress("LongParameterList")
 @Composable
 fun <T> SelectorChip(
     sheetTitle: String,

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/Text.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/Text.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
 import androidx.compose.material3.Text as MaterialText
 
+@Suppress("LongParameterList")
 @Composable
 fun Text(
     text: String,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
@@ -74,6 +74,7 @@ import java.util.Locale
 private const val APK_MIME_TYPE = "application/vnd.android.package-archive"
 private const val ICON_MIME_TYPE = "image/png"
 
+@Suppress("LongParameterList")
 @Composable
 internal fun AppDetailScreen(
     appDetailInput: AppDetailInput,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
@@ -43,7 +43,10 @@ import kotlin.time.toJavaDuration
 private const val TAG = "AppDetailViewModel"
 
 @HiltViewModel(assistedFactory = AppDetailViewModel.Factory::class)
-internal class AppDetailViewModel @AssistedInject constructor(
+internal class AppDetailViewModel
+@Suppress("LongParameterList")
+@AssistedInject
+constructor(
     @Assisted private val appDetailInput: AppDetailInput,
     private val appDetailRepository: AppDetailRepository,
     private val appExportManager: AppExportManager,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentsScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentsScreen.kt
@@ -67,6 +67,7 @@ import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.ListSectionH
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.SectionError
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.SectionLoading
 
+@Suppress("LongParameterList")
 @Composable
 internal fun ComponentsScreen(
     appDetailInput: AppDetailInput,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFiltersScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFiltersScreen.kt
@@ -50,6 +50,7 @@ import sk.styk.martin.apkanalyzer.feature.appdetail.impl.R
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.SectionError
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.SectionLoading
 
+@Suppress("LongParameterList")
 @Composable
 internal fun IntentFiltersScreen(
     appDetailInput: AppDetailInput,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFiltersViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/IntentFiltersViewModel.kt
@@ -34,7 +34,10 @@ import sk.styk.martin.apkanalyzer.feature.appdetail.impl.toAppReference
 private const val TAG = "IntentFiltersViewModel"
 
 @HiltViewModel(assistedFactory = IntentFiltersViewModel.Factory::class)
-internal class IntentFiltersViewModel @AssistedInject constructor(
+internal class IntentFiltersViewModel
+@Suppress("LongParameterList")
+@AssistedInject
+constructor(
     @Assisted private val appDetailInput: AppDetailInput,
     @Assisted private val componentName: String,
     @Assisted private val componentType: ComponentType,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/certificates/CertificatesScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/certificates/CertificatesScreen.kt
@@ -208,6 +208,7 @@ private fun LoadedContent(
     }
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun CertificateCard(
     certificate: CertificateItem,
@@ -454,6 +455,7 @@ private fun ValiditySection(
     }
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun SigningSection(
     signerCount: Int,
@@ -491,6 +493,7 @@ private fun SigningSection(
     }
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun InfoFact(
     label: String,
@@ -680,6 +683,7 @@ private fun FingerprintSection(
     }
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun FingerprintBoxes(
     sha256: String,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/components/InfoRowItem.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/components/InfoRowItem.kt
@@ -25,6 +25,7 @@ internal data class InfoRow(
     val rationale: String,
 )
 
+@Suppress("LongParameterList")
 @Composable
 internal fun InfoRowItem(
     label: String,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/components/SectionCard.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/components/SectionCard.kt
@@ -20,6 +20,7 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.Shapes
 
+@Suppress("LongParameterList")
 @Composable
 internal fun SectionCard(
     title: String,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/manifest/ManifestScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/manifest/ManifestScreen.kt
@@ -203,6 +203,7 @@ private fun ManifestLoadedContent(
     }
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun ManifestDocumentCard(
     state: ManifestState.Loaded,

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsScreen.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsScreen.kt
@@ -73,6 +73,7 @@ import sk.styk.martin.apkanalyzer.feature.apps.impl.components.appitem.AppListIt
 import sk.styk.martin.apkanalyzer.feature.apps.impl.components.quickfilter.QuickFilterRow
 import java.time.Instant
 
+@Suppress("LongParameterList")
 @Composable
 internal fun AppsScreen(
     onAppDetails: (PackageName) -> Unit,
@@ -239,6 +240,7 @@ private fun LazyListScope.recentsSectionItems(
     }
 }
 
+@Suppress("LongParameterList")
 private fun LazyListScope.appsSectionItems(
     apps: AppListState,
     isFiltering: Boolean,

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsViewModel.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsViewModel.kt
@@ -27,7 +27,10 @@ import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
-class AppsViewModel @Inject constructor(
+class AppsViewModel
+@Suppress("LongParameterList")
+@Inject
+constructor(
     installedAppsRepository: InstalledAppsRepository,
     private val recentlyViewedAppsRepository: RecentlyViewedAppsRepository,
     private val appFilterRepository: AppFilterRepository,

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/search/AppSearchViewModel.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/search/AppSearchViewModel.kt
@@ -27,7 +27,10 @@ import sk.styk.martin.apkanalyzer.feature.apps.impl.search.domain.SearchAppsUseC
 import javax.inject.Inject
 
 @HiltViewModel
-class AppSearchViewModel @Inject constructor(
+class AppSearchViewModel
+@Suppress("LongParameterList")
+@Inject
+constructor(
     installedAppsRepository: InstalledAppsRepository,
     private val recentlyViewedAppsRepository: RecentlyViewedAppsRepository,
     private val searchHistoryRepository: SearchHistoryRepository,

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsScreen.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsScreen.kt
@@ -49,6 +49,7 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.theme.Shapes
 import sk.styk.martin.apkanalyzer.feature.browse.impl.R
 import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
 
+@Suppress("LongParameterList")
 @Composable
 internal fun BrowseAppsScreen(
     dimension: BrowseDimension,


### PR DESCRIPTION
## Summary
- group package-analysis inputs in `AppDetailRepositoryImpl` into a cohesive private parameter object
- retain clear Compose and lazy-list call sites with narrow suppressions for 20 idiomatic UI functions
- retain explicit dependency injection and generic flow ergonomics with narrow suppressions for 6 Hilt constructors and the typed six-flow utility

## Suppression rationale
- Compose APIs: named state, callback, and `Modifier` parameters are clearer at call sites than configuration objects; representative locations include `Chip`, `AppDetailScreen`, `CertificatesScreen`, and `AppsScreen`
- Hilt constructors: explicit constructor dependencies preserve the dependency graph and avoid artificial dependency bags; representative locations include `AppDetailRepositoryImpl`, `AppDetailViewModel`, and `AppsViewModel`
- Flow utility: the six typed flow parameters and six-argument transform are the utility's intended contract; wrapping them would reduce type-safe generic ergonomics

## Validation
- `.\gradlew.bat spotlessApply --console=plain`
- `.\gradlew.bat :core:apps:compileDebugKotlin :core:common:compileDebugKotlin :core:ui-library:compileDebugKotlin :feature:app-detail:impl:compileDebugKotlin :feature:apps:impl:compileDebugKotlin :feature:browse:impl:compileDebugKotlin --console=plain`
- `.\gradlew.bat detektDebug :build-logic:convention:detektMain --continue --console=plain` (0 `LongParameterList` findings)

This PR addresses only `LongParameterList`; unrelated Detekt findings are intentionally unchanged.