### PR TITLE
Enable UnusedPrivateProperty Detekt rule

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -71,7 +71,7 @@ style:
   UnusedPrivateFunction:
     allowedNames: '.*Preview'
   UnusedPrivateProperty:
-    active: false
+    active: true
   WildcardImport:
     active: false
 

--- a/core/app-permissions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apppermissions/DevicePermissionsRepositoryImpl.kt
+++ b/core/app-permissions/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apppermissions/DevicePermissionsRepositoryImpl.kt
@@ -14,9 +14,9 @@ import javax.inject.Singleton
 
 @Singleton
 internal class DevicePermissionsRepositoryImpl @Inject constructor(
-    private val installedAppsRepository: InstalledAppsRepository,
-    private val permissionLabelProvider: PermissionLabelProvider,
-    private val dispatcherProvider: DispatcherProvider,
+    installedAppsRepository: InstalledAppsRepository,
+    permissionLabelProvider: PermissionLabelProvider,
+    dispatcherProvider: DispatcherProvider,
     appScope: CoroutineScope,
 ) : DevicePermissionsRepository {
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppSigningRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppSigningRepositoryImpl.kt
@@ -17,8 +17,8 @@ import javax.inject.Inject
 internal class AppSigningRepositoryImpl @Inject constructor(
     private val packageManager: PackageManager,
     private val certificateExtractor: CertificateExtractor,
-    private val packageChangesObserver: PackageChangesObserver,
-    private val dispatcherProvider: DispatcherProvider,
+    packageChangesObserver: PackageChangesObserver,
+    dispatcherProvider: DispatcherProvider,
     appScope: CoroutineScope,
 ) : AppSigningRepository {
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -27,10 +27,10 @@ internal const val INSTALLED_APPS = "InstalledApps"
 internal class InstalledAppsRepositoryImpl @Inject constructor(
     private val packageManager: PackageManager,
     private val installSourceResolver: InstallSourceResolver,
-    private val packageChangesObserver: PackageChangesObserver,
-    private val dispatcherProvider: DispatcherProvider,
-    private val storageStatsRepository: StorageStatsRepository,
-    private val usageStatsRepository: UsageStatsRepository,
+    packageChangesObserver: PackageChangesObserver,
+    dispatcherProvider: DispatcherProvider,
+    storageStatsRepository: StorageStatsRepository,
+    usageStatsRepository: UsageStatsRepository,
     appScope: CoroutineScope,
 ) : InstalledAppsRepository {
 

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/filter/FilterViewModel.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/filter/FilterViewModel.kt
@@ -30,9 +30,9 @@ import javax.inject.Inject
 class FilterViewModel @Inject constructor(
     private val appFilterRepository: AppFilterRepository,
     private val permissionFilterCoordinator: PermissionFilterCoordinator,
-    private val installedAppsRepository: InstalledAppsRepository,
-    private val usageStatsRepository: UsageStatsRepository,
-    private val storageStatsRepository: StorageStatsRepository,
+    installedAppsRepository: InstalledAppsRepository,
+    usageStatsRepository: UsageStatsRepository,
+    storageStatsRepository: StorageStatsRepository,
 ) : ViewModel() {
 
     private val localFilter = MutableStateFlow(appFilterRepository.filter.value)

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/filter/permission/PermissionFilterViewModel.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/filter/permission/PermissionFilterViewModel.kt
@@ -22,7 +22,7 @@ import sk.styk.martin.apkanalyzer.feature.apps.impl.filter.domain.PermissionPres
 import javax.inject.Inject
 
 @HiltViewModel
-class PermissionFilterViewModel @Inject constructor(private val permissionFilterCoordinator: PermissionFilterCoordinator, private val devicePermissionsRepository: DevicePermissionsRepository) : ViewModel() {
+class PermissionFilterViewModel @Inject constructor(private val permissionFilterCoordinator: PermissionFilterCoordinator, devicePermissionsRepository: DevicePermissionsRepository) : ViewModel() {
 
     private val input = permissionFilterCoordinator.consumeInput()
 

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsViewModel.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsViewModel.kt
@@ -31,10 +31,10 @@ class AppsViewModel @Inject constructor(
     installedAppsRepository: InstalledAppsRepository,
     private val recentlyViewedAppsRepository: RecentlyViewedAppsRepository,
     private val appFilterRepository: AppFilterRepository,
-    private val filterApps: FilterAppsUseCase,
+    filterApps: FilterAppsUseCase,
     private val usageStatsRepository: UsageStatsRepository,
     private val storageStatsRepository: StorageStatsRepository,
-    private val dispatcherProvider: DispatcherProvider,
+    dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
 
     private val sortType = MutableStateFlow(SortType.Name)

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/search/AppSearchViewModel.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/search/AppSearchViewModel.kt
@@ -32,8 +32,8 @@ class AppSearchViewModel @Inject constructor(
     private val recentlyViewedAppsRepository: RecentlyViewedAppsRepository,
     private val searchHistoryRepository: SearchHistoryRepository,
     private val appFilterRepository: AppFilterRepository,
-    private val filterApps: FilterAppsUseCase,
-    private val searchApps: SearchAppsUseCase,
+    filterApps: FilterAppsUseCase,
+    searchApps: SearchAppsUseCase,
     dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
 


### PR DESCRIPTION
## Summary
- enable Detekt's `UnusedPrivateProperty` rule
- resolve all 17 initial findings by converting constructor-only injected properties to plain constructor parameters
- keep each dependency available to the flow or state initializer without retaining an unnecessary property

## Findings
- Initial findings: 17
- Private properties removed: 17
- Suppressions added: 0
- Rule configuration exceptions added: 0

No findings required suppression: each reported value was used only while initializing a retained flow or state property, so removing the unnecessary `private val` storage preserves behavior while satisfying the rule.