### PR TITLE
Disable shared search transition in Browse

### DIFF
--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/SearchBarActive.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/SearchBarActive.kt
@@ -26,12 +26,14 @@ fun SearchBarActive(
     query: String,
     placeholder: String,
     modifier: Modifier = Modifier,
+    sharedElementKey: Any? = "search-bar",
     onQueryChange: (String) -> Unit = {},
 ) {
+    val sharedElementModifier = if (sharedElementKey == null) modifier else modifier.sharedElement(key = sharedElementKey)
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .sharedElement(key = "search-bar")
+        modifier = sharedElementModifier
             .fillMaxWidth()
             .heightIn(min = 48.dp)
             .background(

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsScreen.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/apps/BrowseAppsScreen.kt
@@ -130,6 +130,7 @@ private fun BrowseAppsList(
             SearchBarActive(
                 query = state.query,
                 placeholder = pluralStringResource(R.plurals.browse_apps_filter_hint, state.totalApps, state.totalApps),
+                sharedElementKey = null,
                 onQueryChange = { onAction(BrowseAppsAction.ChangeQuery(it)) },
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsScreen.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/options/BrowseOptionsScreen.kt
@@ -137,6 +137,7 @@ private fun BrowseOptionsList(
                 SearchBarActive(
                     query = state.query,
                     placeholder = pluralStringResource(R.plurals.browse_options_filter_hint, state.totalOptions, state.totalOptions),
+                    sharedElementKey = null,
                     onQueryChange = { onAction(BrowseOptionsAction.ChangeQuery(it)) },
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )


### PR DESCRIPTION
## Summary
- allow active search bars to opt out of their shared-element key
- disable the shared search transition between Browse options and app-list screens
- preserve shared search transitions everywhere else