### PR TITLE
Extract content-provider path permissions (EX-08)

### DIFF
--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -47,7 +47,8 @@ model/
                             never "not a launcher"
   Service.kt              - Service component info
   BroadcastReceiver.kt    - Receiver component info
-  ContentProvider.kt      - Provider component info
+  ContentProvider.kt      - Provider component info, incl. `ProviderPathPermission` (`<path-permission>`
+                            entries) and the `ProviderPathMatchType` enum for `PatternMatcher`'s int type
   Certificate.kt          - Certificate details
   CertificatePrincipal.kt - Issuer/subject info
   CertificateTrustLevel.kt - Trust classification enum
@@ -131,14 +132,31 @@ repositories and combine them while mapping to state.
 ## External Entry Semantics
 
 - These rules support the Components screen's technical filter. They are not a risk verdict and do
-  not feed the hub until path permissions provide the remaining context.
+  not feed the hub — that needs a deliberate rule set, not just accurate raw data.
 - Exported alone is not a finding. Launcher activities are expected to be exported and are excluded.
 - An activity is unguarded only when launcher status is known to be false and no permission is required.
 - Services and receivers are unguarded when exported without a required permission.
-- An exported provider is unguarded when either its read or write path lacks a permission.
+- An exported provider is unguarded when either its top-level read or write permission is missing, or
+  any `<path-permission>` entry opens a path without one — see Content Provider Path Permissions.
 - APK activities have unknown launcher status. The technical `Unprotected` filter includes exported
   activities without permission guards and may therefore include the launcher activity; the hub
   does not interpret this as a finding.
+
+## Content Provider Path Permissions
+
+- `ProviderInfo.pathPermissions` is populated by `PackageManager` whenever `GET_PROVIDERS` is
+  queried — unlike intent filters, no manifest parsing is needed, and the flag was already in use.
+  `AnalysisUtils.resolvePathPermissions()` maps it to `ProviderPathPermission`, and `PathPermission`'s
+  `type` int becomes the typed `ProviderPathMatchType` enum.
+- A `<path-permission>` can carve out access that the provider's top-level `readPermission` /
+  `writePermission` does not grant: an entry with neither permission set opens that specific path
+  regardless of what the provider otherwise requires. `ContentProvider.hasUnguardedPathPermission`
+  captures exactly that unambiguous case — it does not attempt to resolve full path-matching
+  precedence when multiple `<path-permission>` entries could overlap.
+- `isExternallyReachableWithoutPermission` folds this in: a provider is reachable without permission
+  if the top level is open **or** any path permission is. It deliberately does not flip the other
+  way — a blank top-level permission still leaves any path not covered by a `<path-permission>` open,
+  so path permissions can only add exposure to the verdict, never resolve it into "guarded."
 
 ## Dependencies
 - `api(projects.core.common)` - exposes common models and DispatcherProvider

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -16,6 +16,7 @@ import sk.styk.martin.apkanalyzer.core.apps.analysis.InstallSourceResolver
 import sk.styk.martin.apkanalyzer.core.apps.analysis.ManifestParser
 import sk.styk.martin.apkanalyzer.core.apps.analysis.SdkVersionResolver
 import sk.styk.martin.apkanalyzer.core.apps.analysis.computeApkSize
+import sk.styk.martin.apkanalyzer.core.apps.analysis.resolvePathPermissions
 import sk.styk.martin.apkanalyzer.core.apps.analysis.resolveProtectionFlags
 import sk.styk.martin.apkanalyzer.core.apps.analysis.resolveProtectionLevel
 import sk.styk.martin.apkanalyzer.core.apps.model.Activity
@@ -230,6 +231,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             readPermission = it.readPermission,
             writePermission = it.writePermission,
             isExported = it.exported,
+            pathPermissions = resolvePathPermissions(it.pathPermissions),
             intentFilters = intentFiltersByComponent[ComponentIntentFilterKey(it.name, ComponentKind.Provider)].orEmpty(),
         )
     }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/AnalysisUtils.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/AnalysisUtils.kt
@@ -1,8 +1,12 @@
 package sk.styk.martin.apkanalyzer.core.apps.analysis
 
+import android.content.pm.PathPermission
 import android.content.pm.PermissionInfo
+import android.os.PatternMatcher
 import sk.styk.martin.apkanalyzer.core.apps.model.ProtectionFlag
 import sk.styk.martin.apkanalyzer.core.apps.model.ProtectionLevel
+import sk.styk.martin.apkanalyzer.core.apps.model.ProviderPathMatchType
+import sk.styk.martin.apkanalyzer.core.apps.model.ProviderPathPermission
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import java.io.File
@@ -28,3 +32,21 @@ private val protectionFlagsByMask = mapOf(
     PermissionInfo.PROTECTION_FLAG_INSTANT to ProtectionFlag.Instant,
     PermissionInfo.PROTECTION_FLAG_DEVELOPMENT to ProtectionFlag.Development,
 )
+
+internal fun resolvePathPermissions(pathPermissions: Array<PathPermission>?): List<ProviderPathPermission> = pathPermissions.orEmpty().map {
+    ProviderPathPermission(
+        path = it.path,
+        matchType = resolvePathMatchType(it.type),
+        readPermission = it.readPermission,
+        writePermission = it.writePermission,
+    )
+}
+
+private fun resolvePathMatchType(type: Int): ProviderPathMatchType = when (type) {
+    PatternMatcher.PATTERN_LITERAL -> ProviderPathMatchType.Literal
+    PatternMatcher.PATTERN_PREFIX -> ProviderPathMatchType.Prefix
+    PatternMatcher.PATTERN_SIMPLE_GLOB -> ProviderPathMatchType.SimpleGlob
+    PatternMatcher.PATTERN_ADVANCED_GLOB -> ProviderPathMatchType.AdvancedGlob
+    PatternMatcher.PATTERN_SUFFIX -> ProviderPathMatchType.Suffix
+    else -> ProviderPathMatchType.Literal
+}

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/ContentProvider.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/ContentProvider.kt
@@ -6,8 +6,28 @@ data class ContentProvider(
     val readPermission: String? = null,
     val writePermission: String? = null,
     val isExported: Boolean = false,
+    val pathPermissions: List<ProviderPathPermission> = emptyList(),
     val intentFilters: List<ComponentIntentFilter> = emptyList(),
 )
 
+data class ProviderPathPermission(
+    val path: String,
+    val matchType: ProviderPathMatchType,
+    val readPermission: String? = null,
+    val writePermission: String? = null,
+)
+
+enum class ProviderPathMatchType {
+    Literal,
+    Prefix,
+    SimpleGlob,
+    AdvancedGlob,
+    Suffix,
+}
+
+val ContentProvider.hasUnguardedPathPermission: Boolean
+    get() = pathPermissions.any { it.readPermission.isNullOrBlank() || it.writePermission.isNullOrBlank() }
+
 val ContentProvider.isExternallyReachableWithoutPermission: Boolean
-    get() = isExported && (readPermission.isNullOrBlank() || writePermission.isNullOrBlank())
+    get() = isExported &&
+        (readPermission.isNullOrBlank() || writePermission.isNullOrBlank() || hasUnguardedPathPermission)

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -60,4 +60,4 @@ When a feature ships, update the roadmap status for its IDs and mark the feature
 
 | Doc                                | Roadmap IDs                     | Status                            |
 |------------------------------------|---------------------------------|------------------------------------|
-| [App detail](features/app-detail.md) | FR-10 … FR-18, FR-25, plus EX-07, EX-08 | Shipped — Libraries scope (FR-44) and exposure interpretation (EX-08) still pending |
+| [App detail](features/app-detail.md) | FR-10 … FR-18, FR-25, plus EX-07, EX-08 | Shipped — Libraries scope (FR-44) and a hub exposure rule (RI-03) still pending |

--- a/docs/product/features/app-detail.md
+++ b/docs/product/features/app-detail.md
@@ -2,10 +2,11 @@
 
 **Roadmap:** [FR-10 … FR-18](../roadmap.md#12-app-detail), [FR-25](../roadmap.md#15-export--share), plus [EX-07, EX-08](../roadmap.md#18-data-gaps--extraction-that-doesnt-exist-yet) · R0
 **Status:** Shipped. [All six implementation steps](#implementation-order) are built and wired,
-including Requirements and the polish pass. Two pieces described below are still open, both blocked
-on roadmap data-extraction items rather than on this design: the Requirements `Libraries` scope
-(needs `FR-44`) and exported-component risk interpretation on the hub and in `FR-17` (needs
-`EX-08` — `EX-07`'s intent filters have landed and already back the Components item sheets).
+including Requirements and the polish pass. Two pieces described below are still open: the
+Requirements `Libraries` scope, blocked on roadmap data-extraction item `FR-44`; and exported-
+component risk interpretation on the hub, which now has all its data (`EX-07` and `EX-08` have both
+landed and back the Components screen's filter and item sheet) but still needs a deliberate hub rule
+rather than more extraction — see `RI-03`.
 **Scope:** surface everything `AppDetail` holds inside `feature:app-detail`, provide a readable
 manifest, and finish base-APK and icon export.
 
@@ -616,10 +617,12 @@ Screen work:
 ### Step 5 — Hub rework — Shipped
 
 - Card previews: dangerous permission group icons, certificate validity line and self-signed note,
-  and required/optional feature split. Components stay as neutral per-type counts until path
-  permissions (`EX-08`) provide the remaining evidence needed to interpret exposure. **Still
-  true** — `EX-07`'s intent filters landed and now back the Components item sheets, but `EX-08`
-  hasn't, so component exposure stays out of both the card preview and the "Worth knowing" rule set.
+  and required/optional feature split. Components stay as neutral per-type counts. **Updated** —
+  `EX-07` (intent filters) and `EX-08` (content-provider path permissions) have both landed and back
+  the Components screen's `Unprotected` filter and item sheet, so the extraction gap this step
+  originally cited is closed. What's still missing is a deliberate hub rule to turn that technical
+  filter into a "Worth knowing" finding (see `RI-03`), not more data — component exposure stays out
+  of the card preview and the rule set until that rule is designed and built.
 - "Worth knowing" card with its rule set: enabled debug access, debug or not-yet-valid certificate,
   a target at least four API levels behind the device, and actually granted high-impact access such
   as background location, messages, call history, contacts, or calendar. Backup and cleartext flags

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -101,7 +101,7 @@ What Changed tab in R1.
 | FR-14 | Certificate detail view             | Done    | Full signer, validity, signing status, serial, certificate fingerprints, and expandable public-key fingerprints |
 | FR-15 | Features (uses-feature) view        | Done    | `feature:app-detail` → `requirements`; required/optional split, per-device check, dedicated GL ES handling. `Libraries` scope still needs `FR-44` |
 | FR-16 | Manifest viewer                     | Done    | Readable namespaced XML with line-based search for installed packages and APK files |
-| FR-17 | Exported components view            | Partial | Exported/Unprotected filter chips ship in the Components screen (`FR-13`), and the item sheet shows every declared intent filter (`EX-07`, done). Still a technical filter, not a risk verdict — needs content-provider path permissions (`EX-08`) before exposure can be interpreted |
+| FR-17 | Exported components view            | Partial | Exported/Unprotected filter chips ship in the Components screen (`FR-13`), backed by both intent filters (`EX-07`) and content-provider path permissions (`EX-08`), both done. Still a technical filter, not a risk verdict — needs a deliberate hub rule (see `RI-03`) before exposure becomes a "Worth knowing" finding |
 | FR-18 | Custom permission audit             | Partial | Permissions screen's `Defined` scope lists the app's declared permissions with full detail sheets; no audit judgment (e.g. protection-level risk) applied yet |
 
 ### 1.3 APK File Analysis
@@ -159,7 +159,7 @@ doing in R0 rather than later.
 | FR-38 | Full install-source chain         | Todo   | Only `installingPackageName` is read; initiating + originating package are what actually distinguish a sideload from a store install |
 | FR-39 | App category                      | Todo   | One field; unlocks the `FR-43` browse dimension                                                      |
 | EX-07 | Component intent filters          | Done   | What an exported component actually responds to. Backs `ComponentIntentFilterKey` / `IntentFiltersScreen` in the Components screen (`FR-13`) and is available for `RI-03`. `EX-08` is the remaining half `FR-17` needs before exposure becomes a hub finding |
-| EX-08 | Content-provider path permissions | Todo   | `<path-permission>` read/write grants per path, not currently extracted. The last piece `FR-17` needs — a provider exported without a top-level permission can still be guarded per-path, and `EX-07`'s intent filters don't cover providers |
+| EX-08 | Content-provider path permissions | Done   | `<path-permission>` read/write grants per path, read straight off `ProviderInfo.pathPermissions` (already fetched via `GET_PROVIDERS`, no manifest parsing needed). Feeds the Components screen's `Unprotected` filter and item sheet; hub interpretation still needs a rule, tracked under `RI-03` |
 | FR-44 | Declared `<uses-library>` entries  | Todo   | Name and `android:required`, from the manifest for APK files and `sharedLibraryFiles` for installed apps. The platform-library half of device requirements — `org.apache.http.legacy` on a modern app is a signal the hardware list cannot give |
 
 **R0 scope:** CE-01, CE-05, FR-08 … FR-21, FR-24 … FR-44, EX-07, EX-08. Excludes the retired FR-22/FR-23 and the backlogged CE-06.

--- a/feature/app-detail/AGENTS.md
+++ b/feature/app-detail/AGENTS.md
@@ -112,14 +112,18 @@ ComponentsAction.kt / ComponentsEvent.kt
 
 One screen for all four component types; the scope selector carries the type, so the hub's four
 component rows deep-link with their scope preselected. Under scope `All` the list is sectioned by
-type. Exported items sort first. `isGuarded` folds a provider's read/write permissions and the other
-types' single `permission` into one flag, so `isUnprotected` (exported and unguarded) means the same
-thing everywhere. The component sheet shows every declared intent filter as the requests, links,
-and content that can reach that component. It shows only a filter count and links to a searchable
-full-screen list; filter counts do not appear on component rows because quantity is not a risk
-signal. A manifest parsing failure remains explicit in the component sheet but does not fail the
-rest of app detail. Path permissions are not extracted yet, so exposure
-still does not feed the hub's "Worth knowing" card.
+type. Exported items sort first. `isGuarded` folds a provider's read/write permissions, its
+`<path-permission>` entries, and the other types' single `permission` into one flag, so
+`isUnprotected` (exported and unguarded) means the same thing everywhere. The component sheet shows
+every declared intent filter as the requests, links, and content that can reach that component, plus
+— for providers — every `<path-permission>` entry with its path, match type explanation, and
+per-path read/write permission (`components_detail_section_path_permissions`); a path entry with
+neither permission set is what makes an otherwise-guarded provider `isUnprotected`. It shows only a
+filter count and links to a searchable full-screen list; filter counts do not appear on component
+rows because quantity is not a risk signal. A manifest parsing failure remains explicit in the
+component sheet but does not fail the rest of app detail. Path permissions are extracted and drive
+the Components screen's own filter now, but exposure still does not feed the hub's "Worth knowing"
+card — that needs a deliberate rule, not just accurate raw data.
 `isLaunchable` is deliberately *not* `isUnprotected`: it is exported-and-unguarded (which is exactly
 "we are allowed to start it") in `InstalledPackage` mode, for activities and receivers only. Launcher
 activities are the most launchable thing there is, so reusing `isUnprotected` would hide the run

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentDetailBottomSheet.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentDetailBottomSheet.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import sk.styk.martin.apkanalyzer.core.apps.model.IntentFilterDataRuleType
+import sk.styk.martin.apkanalyzer.core.apps.model.ProviderPathMatchType
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.BottomSheet
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.Icon
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.Text
@@ -104,6 +105,37 @@ internal fun ComponentDetailBottomSheet(
                         details.writePermission?.let {
                             DetailField(label = stringResource(R.string.components_detail_write_permission), value = it, onCopy = onCopy)
                         }
+                    }
+                }
+            }
+
+            val providerDetails = item.details as? ComponentDetails.ProviderDetails
+            if (providerDetails != null && providerDetails.pathPermissions.isNotEmpty()) {
+                SheetSection(title = stringResource(R.string.components_detail_section_path_permissions)) {
+                    Text(
+                        text = stringResource(R.string.components_detail_path_permissions_explanation),
+                        style = AppTheme.typography.bodySmall,
+                        color = AppTheme.colors.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    providerDetails.pathPermissions.forEachIndexed { index, pathPermission ->
+                        if (index > 0) Spacer(modifier = Modifier.height(12.dp))
+                        DetailField(
+                            label = stringResource(R.string.components_detail_path_permission_path),
+                            value = pathPermission.path,
+                            explanation = stringResource(pathPermission.matchType.explanationRes),
+                            onCopy = onCopy,
+                        )
+                        DetailField(
+                            label = stringResource(R.string.components_detail_read_permission),
+                            value = pathPermission.readPermission ?: stringResource(R.string.components_detail_path_permission_open),
+                            onCopy = onCopy,
+                        )
+                        DetailField(
+                            label = stringResource(R.string.components_detail_write_permission),
+                            value = pathPermission.writePermission ?: stringResource(R.string.components_detail_path_permission_open),
+                            onCopy = onCopy,
+                        )
                     }
                 }
             }
@@ -317,6 +349,43 @@ private fun ComponentDetailBottomSheetProviderPreview() {
                     authority = "com.spotify.music.androidx-startup",
                     readPermission = null,
                     writePermission = null,
+                    pathPermissions = persistentListOf(),
+                ),
+            ),
+            onCopy = { _, _ -> },
+            onOpenIntentFilters = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ComponentDetailBottomSheetProviderPathPermissionPreview() {
+    ApkAnalyzerTheme {
+        ComponentDetailBottomSheet(
+            item = ComponentItem(
+                name = "com.spotify.music.sharing.SharingProvider",
+                simpleName = "SharingProvider",
+                packagePath = "com.spotify.music.sharing",
+                type = ComponentType.Provider,
+                isExported = true,
+                isGuarded = false,
+                isUnprotected = true,
+                isLaunchable = false,
+                flags = persistentListOf(),
+                details = ComponentDetails.ProviderDetails(
+                    authority = "com.spotify.music.sharing",
+                    readPermission = "com.spotify.music.permission.ACCESS_SHARING",
+                    writePermission = "com.spotify.music.permission.ACCESS_SHARING",
+                    pathPermissions = persistentListOf(
+                        ProviderPathPermissionItem(
+                            path = "/public",
+                            matchType = ProviderPathMatchType.Prefix,
+                            readPermission = null,
+                            writePermission = null,
+                        ),
+                    ),
                 ),
             ),
             onCopy = { _, _ -> },

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentResources.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentResources.kt
@@ -4,6 +4,7 @@ import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.vector.ImageVector
 import sk.styk.martin.apkanalyzer.core.apps.model.IntentFilterDataRuleType
+import sk.styk.martin.apkanalyzer.core.apps.model.ProviderPathMatchType
 import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.R
 
@@ -97,4 +98,14 @@ internal val IntentFilterDataRuleType.labelRes: Int
         IntentFilterDataRuleType.FragmentAdvancedPattern -> R.string.components_intent_data_fragment_advanced_pattern
         IntentFilterDataRuleType.MimeType -> R.string.components_intent_data_mime_type
         IntentFilterDataRuleType.MimeGroup -> R.string.components_intent_data_mime_group
+    }
+
+@get:StringRes
+internal val ProviderPathMatchType.explanationRes: Int
+    get() = when (this) {
+        ProviderPathMatchType.Literal -> R.string.components_path_permission_type_literal
+        ProviderPathMatchType.Prefix -> R.string.components_path_permission_type_prefix
+        ProviderPathMatchType.SimpleGlob -> R.string.components_path_permission_type_simple_glob
+        ProviderPathMatchType.AdvancedGlob -> R.string.components_path_permission_type_advanced_glob
+        ProviderPathMatchType.Suffix -> R.string.components_path_permission_type_suffix
     }

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentsState.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentsState.kt
@@ -6,6 +6,7 @@ import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.serialization.Serializable
 import sk.styk.martin.apkanalyzer.core.apps.model.IntentFilterDataRuleType
+import sk.styk.martin.apkanalyzer.core.apps.model.ProviderPathMatchType
 
 @Serializable
 internal enum class ComponentScope {
@@ -60,8 +61,17 @@ internal sealed interface ComponentDetails {
         val authority: String?,
         val readPermission: String?,
         val writePermission: String?,
+        val pathPermissions: ImmutableList<ProviderPathPermissionItem>,
     ) : ComponentDetails
 }
+
+@Immutable
+internal data class ProviderPathPermissionItem(
+    val path: String,
+    val matchType: ProviderPathMatchType,
+    val readPermission: String?,
+    val writePermission: String?,
+)
 
 @Immutable
 internal data class ComponentItem(

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentsViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/appcomponents/ComponentsViewModel.kt
@@ -25,6 +25,7 @@ import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
 import sk.styk.martin.apkanalyzer.core.apps.model.BroadcastReceiver
 import sk.styk.martin.apkanalyzer.core.apps.model.ContentProvider
 import sk.styk.martin.apkanalyzer.core.apps.model.Service
+import sk.styk.martin.apkanalyzer.core.apps.model.hasUnguardedPathPermission
 import sk.styk.martin.apkanalyzer.core.apps.model.isExternallyReachableWithoutPermission
 import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
 import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
@@ -216,7 +217,7 @@ private fun ContentProvider.toItem(areIntentFiltersAvailable: Boolean) = Compone
     packagePath = name.substringBeforeLast('.', ""),
     type = ComponentType.Provider,
     isExported = isExported,
-    isGuarded = !readPermission.isNullOrBlank() && !writePermission.isNullOrBlank(),
+    isGuarded = !readPermission.isNullOrBlank() && !writePermission.isNullOrBlank() && !hasUnguardedPathPermission,
     isUnprotected = isExternallyReachableWithoutPermission,
     isLaunchable = false,
     flags = emptyImmutableFlags,
@@ -226,6 +227,14 @@ private fun ContentProvider.toItem(areIntentFiltersAvailable: Boolean) = Compone
         authority = authority,
         readPermission = readPermission,
         writePermission = writePermission,
+        pathPermissions = pathPermissions.map {
+            ProviderPathPermissionItem(
+                path = it.path,
+                matchType = it.matchType,
+                readPermission = it.readPermission,
+                writePermission = it.writePermission,
+            )
+        }.toImmutableList(),
     ),
 )
 

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -441,6 +441,15 @@
     <string name="components_detail_target_activity">Target activity</string>
     <string name="components_detail_parent">Parent activity</string>
     <string name="components_detail_authority">Authority</string>
+    <string name="components_detail_section_path_permissions">Path permissions</string>
+    <string name="components_detail_path_permissions_explanation">Rules for specific paths under this provider. A path can grant or remove access beyond the general read and write permissions above.</string>
+    <string name="components_detail_path_permission_path">Path</string>
+    <string name="components_detail_path_permission_open">No permission required</string>
+    <string name="components_path_permission_type_literal">Matches this exact path</string>
+    <string name="components_path_permission_type_prefix">Matches this path and everything under it</string>
+    <string name="components_path_permission_type_simple_glob">Matches this path using a wildcard pattern</string>
+    <string name="components_path_permission_type_advanced_glob">Matches this path using an advanced wildcard pattern</string>
+    <string name="components_path_permission_type_suffix">Matches any path ending with this</string>
 
     <string name="permissions_detail_full_name">Full name</string>
     <string name="permissions_detail_grant_state">Grant state</string>


### PR DESCRIPTION
## Summary
- `ProviderInfo.pathPermissions` is available off the `GET_PROVIDERS` query the app already runs, but was unread — so a provider requiring a top-level read/write permission could still leave a specific path wide open via an unguarded `<path-permission>`, and the Components screen's `Unprotected` filter had no way to catch it.
- Adds a typed `ProviderPathPermission` / `ProviderPathMatchType` model in `core:apps`, maps it in `AppDetailRepositoryImpl`, and folds an unguarded path into `ContentProvider.isExternallyReachableWithoutPermission` and the Components screen's `isGuarded` — deliberately one-directional: a blank top-level permission still leaves any path not covered by a `<path-permission>` open, so path permissions can only add exposure, never resolve a provider to "guarded".
- Surfaces every path permission in the provider item sheet (path, plain-language match-type explanation, read/write requirement), matching the existing tap-to-copy idiom.
- Updates `core/apps/AGENTS.md`, `feature/app-detail/AGENTS.md`, `docs/product/roadmap.md`, and `docs/product/features/app-detail.md` to mark roadmap item `EX-08` done. The remaining piece of `FR-17` is a deliberate hub "Worth knowing" rule (tracked under `RI-03`), not more data extraction.

## Test plan
- [x] `:core:apps:compileDebugKotlin` and `:feature:app-detail:impl:compileDebugKotlin`
- [x] `spotlessApply`
- [x] `detektDebug` on both modules (only pre-existing-style advisory `LongMethod`/`MagicNumber` findings, no new blocking findings)
- [x] `validateAgentContext`
- [x] `:app:assembleDebug`
- [ ] Manual check on device: a content provider with a `<path-permission>` hole renders correctly in the Components screen's item sheet and trips the `Unprotected` filter