### PR TITLE
Parallelize CI verification and artifact builds

### DIFF
--- a/.claude/skills/analyze-ci-failure/SKILL.md
+++ b/.claude/skills/analyze-ci-failure/SKILL.md
@@ -9,20 +9,20 @@ description: Use to check GitHub Actions build status or diagnose why a workflow
 
 ## Workflows in this repo
 
-Both live at `.github/workflows/`.
+They live at `.github/workflows/`.
 
 | File | Name | Trigger | What it runs |
 |---|---|---|---|
-| `.github/workflows/android.yml` | `Continuous integration` | Push to or pull request against `develop` | `build`: `spotlessCheck`, `lintDebug`, `assembleDebug`; `distribute` on pushes: Firebase App Distribution |
-| `.github/workflows/android-publish.yml` | `Release` | Push of a semantic version tag (`X.Y.Z`) | `build`: lint, version, build, sign, artifacts, GitHub release; parallel Play Store beta and Firebase App Distribution jobs |
+| `.github/workflows/ci.yml` | `Continuous integration` | Push to or pull request against `develop` | Parallel `verify` and `build-apk` jobs; `distribute` on pushes after both pass |
+| `.github/workflows/release.yml` | `Release` | Push of a semantic version tag (`X.Y.Z`) | Parallel `verify` and `build-release` jobs; GitHub Release, Play Store beta, and Firebase App Distribution publish after both pass |
 | `.github/workflows/agent-context.yml` | `Agent context` | Context, skill, adapter, root-build, or module-graph changes against `develop` | `validate`: `validateAgentContext` |
 
 ## Step 1 — Find the run
 
 | Given | Command |
 |---|---|
-| "latest build" / "latest CI run" | `gh run list --workflow android.yml --limit 5` |
-| "latest release run" | `gh run list --workflow android-publish.yml --limit 5` |
+| "latest build" / "latest CI run" | `gh run list --workflow ci.yml --limit 5` |
+| "latest release run" | `gh run list --workflow release.yml --limit 5` |
 | "latest context check" | `gh run list --workflow agent-context.yml --limit 5` |
 | A run ID or run URL | `gh run view <run-id>` |
 | A PR number | `gh pr checks <pr-number>` |
@@ -31,9 +31,10 @@ Both live at `.github/workflows/`.
 ## Step 2 — Check job-level status, not just the run-level conclusion
 
 `gh run view <run-id>` prints a ✓/X per job — read this before pulling logs. The Android workflows
-have downstream distribution jobs, and the release workflow also has a Play Store job. Confirm the
-failed job and its dependencies before assuming the cause; a downstream artifact failure may still
-originate in `build`.
+have parallel verification and artifact-build jobs followed by downstream distribution jobs. The
+release workflow also has Play Store and GitHub Release jobs. Confirm the failed job and its
+dependencies before assuming the cause; a downstream artifact failure may still originate in
+`build-apk` or `build-release`.
 
 ## Step 3 — Pull only the failing job's log, then filter for the signal
 
@@ -68,7 +69,7 @@ Gradle task.
 | `BUILD FAILED` with ktlint-style messages or Compose compile errors traceable to formatting | Unformatted/violating Kotlin broke compilation | Use the `spotless-fix` skill |
 | `e: file:///path/to/File.kt:12:5 ...` | Kotlin compiler error, points directly at file:line | Open the file, fix per `AGENTS.md` conventions |
 | `Fetch Firebase google-services.json` fails in either workflow | `FIREBASE_TOKEN`, `FIREBASE_APP_ID`, or `FIREBASE_PROJECT_ID` is missing/wrong, or the token cannot access the configured Firebase project/app | Use `gh secret list` to confirm all three exist. Secret values are masked and Firebase access cannot be repaired from logs; report the exact Firebase CLI error to the user |
-| Signing step fails in `android-publish.yml` (`sign_aab` or `sign_apk`) | One of `SIGN_KEY`, `SIGN_KEY_ALIAS`, `SIGN_KEY_STORE_PASSWORD`, `SIGN_KEY_PASSWORD` repo secrets is missing/wrong, or the keystore is corrupt/mismatched with the alias | `gh secret list` to confirm all four exist; can't verify the keystore itself from CI logs — ask the user to check it locally |
+| Signing step fails in `release.yml` (`sign_aab` or `sign_apk`) | One of `SIGN_KEY`, `SIGN_KEY_ALIAS`, `SIGN_KEY_STORE_PASSWORD`, `SIGN_KEY_PASSWORD` repo secrets is missing/wrong, or the keystore is corrupt/mismatched with the alias | `gh secret list` to confirm all four exist; can't verify the keystore itself from CI logs — ask the user to check it locally |
 | `Deploy to Play Store` step fails with an auth/permission error | `GOOGLE_SERVICE_ACCOUNT` secret is missing, expired, or the service account lacks Play Console API access for `sk.styk.martin.apkanalyzer` | Check `gh secret list`; Play Console access itself can't be fixed from CI — flag to the user |
 | `Distribute APK to Firebase App Distribution` fails after a successful build | `FIREBASE_TOKEN`/`FIREBASE_APP_ID` is wrong, the token lacks access, or the `internal-testers` group is unavailable | Confirm both secrets exist with `gh secret list`, then report the Firebase CLI error; project permissions and tester groups require user access |
 | A future JDK bump to the Gradle toolchain (`jvmToolchain(N)`, `gradle-daemon-jvm.properties`) isn't mirrored in one of the two workflows' `setup-java` step | **Usually not the actual failure cause even if they briefly drift** — `gradle-daemon-jvm.properties` has `toolchainUrl.*` entries for the foojay Disco API, so Gradle auto-downloads a matching JDK regardless of the JDK `setup-java` installed (needs the `org.gradle.toolchains.foojay-resolver-convention` plugin in `settings.gradle.kts`, which is applied). Don't assume a JDK mismatch is the root cause without other evidence | If you do suspect it, search the log for `Downloading` / `Unpacking JDK` lines from the toolchain auto-provisioning, or a `No matching toolchains found` error, before concluding this is the cause |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,11 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,15 +48,13 @@ jobs:
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
         run: |
           rm -f app/google-services.json
-          npx firebase-tools@latest apps:sdkconfig ANDROID "$FIREBASE_APP_ID" \
+          npx --yes firebase-tools@15.26.0 apps:sdkconfig ANDROID "$FIREBASE_APP_ID" \
             --project "$FIREBASE_PROJECT_ID" \
             -o app/google-services.json
 
-      - name: Spotless check
-        run: ./gradlew spotlessCheck
-
-      - name: Detekt check
-        run: ./gradlew detektDebug :build-logic:convention:detektMain --continue
+      - name: Verify project
+        run: |
+          ./gradlew spotlessCheck detektDebug :build-logic:convention:detektMain lintDebug --continue
 
       - name: Collect Detekt SARIF reports
         if: always()
@@ -91,8 +92,34 @@ jobs:
         with:
           sarif_file: build/reports/detekt.sarif
 
-      - name: Lint check
-        run: ./gradlew lintDebug
+  build-apk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Fetch Firebase google-services.json
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+        run: |
+          rm -f app/google-services.json
+          npx --yes firebase-tools@15.26.0 apps:sdkconfig ANDROID "$FIREBASE_APP_ID" \
+            --project "$FIREBASE_PROJECT_ID" \
+            -o app/google-services.json
 
       - name: Build debug APK
         run: |
@@ -101,7 +128,7 @@ jobs:
           else
             VERSION_NAME="dev.$GITHUB_RUN_NUMBER"
           fi
-          ./gradlew :app:assembleDebug -Pversion.name=$VERSION_NAME
+          ./gradlew :app:assembleDebug -Pversion.name="$VERSION_NAME"
 
       - name: Rename APK
         run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/apk-analyzer.apk
@@ -112,9 +139,11 @@ jobs:
           name: apk-analyzer
           path: app/build/outputs/apk/debug/apk-analyzer.apk
           retention-days: 14
+          compression-level: 0
+          if-no-files-found: error
 
   distribute:
-    needs: build
+    needs: [ verify, build-apk ]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
@@ -141,7 +170,7 @@ jobs:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
         run: |
-          npx firebase-tools@latest appdistribution:distribute artifacts/apk-analyzer.apk \
+          npx --yes firebase-tools@15.26.0 appdistribution:distribute artifacts/apk-analyzer.apk \
             --app "$FIREBASE_APP_ID" \
             --groups "internal-testers" \
             --release-notes-file release-notes.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,15 @@ on:
     tags:
       - '+([0-9]).+([0-9]).+([0-9])'
 
+permissions:
+  contents: read
+
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
-    outputs:
-      apk_name: apk-analyzer-${{ github.ref_name }}.apk
-      aab_name: apk-analyzer-${{ github.ref_name }}.aab
 
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5
@@ -36,12 +34,45 @@ jobs:
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
         run: |
           rm -f app/google-services.json
-          npx firebase-tools@latest apps:sdkconfig ANDROID "$FIREBASE_APP_ID" \
+          npx --yes firebase-tools@15.26.0 apps:sdkconfig ANDROID "$FIREBASE_APP_ID" \
             --project "$FIREBASE_PROJECT_ID" \
             -o app/google-services.json
 
-      - name: Lint check
-        run: ./gradlew lintRelease
+      - name: Verify release
+        run: |
+          ./gradlew spotlessCheck detektDebug :build-logic:convention:detektMain lintRelease --continue
+
+  build-release:
+    runs-on: ubuntu-latest
+    outputs:
+      apk_name: apk-analyzer-${{ github.ref_name }}.apk
+      aab_name: apk-analyzer-${{ github.ref_name }}.aab
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Fetch Firebase google-services.json
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+        run: |
+          rm -f app/google-services.json
+          npx --yes firebase-tools@15.26.0 apps:sdkconfig ANDROID "$FIREBASE_APP_ID" \
+            --project "$FIREBASE_PROJECT_ID" \
+            -o app/google-services.json
 
       - name: Compute versionCode from tag
         id: version
@@ -53,7 +84,7 @@ jobs:
         run: |
           ./gradlew bundleRelease assembleRelease \
             -Pversion.code=${{ steps.version.outputs.code }} \
-            -Pversion.name=$GITHUB_REF_NAME
+            -Pversion.name="$GITHUB_REF_NAME"
 
       - name: Sign AAB
         uses: r0adkll/sign-android-release@v1
@@ -85,18 +116,40 @@ jobs:
         with:
           name: apk-analyzer-aab
           path: app/build/outputs/bundle/release/apk-analyzer-${{ github.ref_name }}.aab
+          compression-level: 0
+          if-no-files-found: error
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: apk-analyzer-apk
           path: app/build/outputs/apk/release/apk-analyzer-${{ github.ref_name }}.apk
+          compression-level: 0
+          if-no-files-found: error
 
       - name: Upload mapping file artifact
         uses: actions/upload-artifact@v4
         with:
           name: apk-analyzer-mapping
           path: app/build/outputs/mapping/release/mapping.txt
+          if-no-files-found: error
+
+  publish-github-release:
+    needs: [ verify, build-release ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Download APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: apk-analyzer-apk
+          path: artifacts
 
       - name: Read tag annotation as release notes
         id: notes
@@ -113,11 +166,12 @@ jobs:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           body: ${{ steps.notes.outputs.body }}
-          files: app/build/outputs/apk/release/apk-analyzer-${{ github.ref_name }}.apk
+          files: artifacts/${{ needs['build-release'].outputs.apk_name }}
 
   publish-play-store:
-    needs: build
+    needs: [ verify, build-release ]
     runs-on: ubuntu-latest
+
     steps:
       - name: Download AAB artifact
         uses: actions/download-artifact@v4
@@ -136,14 +190,15 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
           packageName: sk.styk.martin.apkanalyzer
-          releaseFiles: artifacts/${{ needs.build.outputs.aab_name }}
+          releaseFiles: artifacts/${{ needs['build-release'].outputs.aab_name }}
           mappingFile: artifacts/mapping.txt
           track: beta
           status: completed
 
   distribute-app-distribution:
-    needs: build
+    needs: [ verify, build-release ]
     runs-on: ubuntu-latest
+
     steps:
       - name: Download APK artifact
         uses: actions/download-artifact@v4
@@ -156,7 +211,7 @@ jobs:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
         run: |
-          npx firebase-tools@latest appdistribution:distribute "artifacts/${{ needs.build.outputs.apk_name }}" \
+          npx --yes firebase-tools@15.26.0 appdistribution:distribute "artifacts/${{ needs['build-release'].outputs.apk_name }}" \
             --app "$FIREBASE_APP_ID" \
             --groups "internal-testers" \
             --release-notes "${{ github.ref_name }}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ApkAnalyzer
 
-[![Continuous integration](https://github.com/MartinStyk/AndroidApkAnalyzer/actions/workflows/android.yml/badge.svg)](https://github.com/MartinStyk/AndroidApkAnalyzer/actions/workflows/android.yml)
-[![Release](https://github.com/MartinStyk/AndroidApkAnalyzer/actions/workflows/android-publish.yml/badge.svg)](https://github.com/MartinStyk/AndroidApkAnalyzer/actions/workflows/android-publish.yml)
+[![Continuous integration](https://github.com/MartinStyk/AndroidApkAnalyzer/actions/workflows/ci.yml/badge.svg)](https://github.com/MartinStyk/AndroidApkAnalyzer/actions/workflows/ci.yml)
+[![Release](https://github.com/MartinStyk/AndroidApkAnalyzer/actions/workflows/release.yml/badge.svg)](https://github.com/MartinStyk/AndroidApkAnalyzer/actions/workflows/release.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.4.10-blue.svg?logo=kotlin)](gradle/libs.versions.toml)
 


### PR DESCRIPTION
CI currently runs verification and artifact assembly serially, delaying PR feedback and development distributions. This restructures the pipelines so independent work runs concurrently while every publication remains gated on successful verification and artifact creation.

## Changes

- Split continuous integration into parallel `verify` and `build-apk` jobs, with Firebase distribution depending on both.
- Split tagged releases into parallel `verify` and `build-release` jobs, with GitHub Release, Play Store, and Firebase publication depending on both.
- Consolidate verification tasks into one Gradle invocation and pin Firebase CLI to `15.26.0`.
- Rename the workflows to `ci.yml` and `release.yml`, updating badges and CI troubleshooting guidance.
- Disable artifact compression for already-compressed APK and AAB files.

## Validation

- `./gradlew spotlessCheck detektDebug :build-logic:convention:detektMain lintDebug --continue`
- `./gradlew :app:assembleDebug -Pversion.name=ci-validation`
- `./gradlew validateAgentContext`