### PR TITLE
Publish Android Lint findings alongside Detekt SARIF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,41 +56,15 @@ jobs:
         run: |
           ./gradlew spotlessCheck detektDebug :build-logic:convention:detektMain lintDebug --continue
 
-      - name: Collect Detekt SARIF reports
+      - name: Merge SARIF reports
         if: always()
-        run: |
-          mkdir -p build/reports/detekt-sarif
-          find . -type f -path '*/build/reports/detekt/*.sarif' -print0 |
-            while IFS= read -r -d '' report; do
-              destination="build/reports/detekt-sarif/${report#./}"
-              mkdir -p "$(dirname "$destination")"
-              cp "$report" "$destination"
-            done
-          mapfile -d '' reports < <(find build/reports/detekt-sarif -type f -name '*.sarif' -print0 | sort -z)
-          if (( ${#reports[@]} == 0 )); then
-            echo "No Detekt SARIF reports found" >&2
-            exit 1
-          fi
-          jq -s '
-            . as $reports
-            | $reports[0] as $first
-            | (
-                $first.runs[0]
-                | .tool.driver.rules = ([$reports[].runs[0].tool.driver.rules[]?] | unique_by(.id))
-                | .results = [$reports[].runs[0].results[]?]
-              ) as $run
-            | {
-                "$schema": $first["$schema"],
-                "version": $first.version,
-                "runs": [$run]
-              }
-          ' "${reports[@]}" > build/reports/detekt.sarif
+        run: ./gradlew mergeSarifReports
 
-      - name: Upload Detekt SARIF reports
+      - name: Upload SARIF reports
         if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: build/reports/detekt.sarif
+          sarif_file: build/reports/merged.sarif
 
   build-apk:
     runs-on: ubuntu-latest

--- a/build-logic/AGENTS.md
+++ b/build-logic/AGENTS.md
@@ -18,6 +18,7 @@ Gradle convention plugins that standardize build configuration across all module
 | `apkanalyzer.compose` | `ComposePlugin.kt` | `kotlin.compose` + `kotlin.serialization` + Compose BOM + compose bundle + navigation3 bundle |
 | `apkanalyzer.spotless` | `SpotlessPlugin.kt` | Spotless + ktlint + compose-rules-ktlint custom ruleset |
 | `apkanalyzer.detekt` | `DetektPlugin.kt` | Baseline-free, type-resolved Kotlin static analysis using the shared root configuration |
+| `apkanalyzer.sarif-merge` | `SarifMergePlugin.kt` | Root-only `mergeSarifReports` task that combines every module's Detekt and Lint SARIF reports into one file for upload |
 
 ## Utility Files (`utils/`)
 
@@ -40,6 +41,17 @@ Gradle convention plugins that standardize build configuration across all module
 - Android modules analyze the debug variant with type resolution
 - `build-logic` analyzes its main JVM source set
 - CI runs every Android module's `detektDebug` task and `build-logic:convention:detektMain`
+
+## SARIF Reporting
+- Detekt (`dev.detekt`) and Android Lint (AGP) both emit a per-module `.sarif` report by default —
+  no explicit `reports {}`/`lint {}` config is needed to turn SARIF on.
+- The root-only `mergeSarifReports` task (`apkanalyzer.sarif-merge`) globs every module's
+  `build/reports/detekt/*.sarif` and `build/reports/lint-results-*.sarif` and merges them into
+  `build/reports/merged.sarif` using Detekt's own `ReportMergeTask` — no custom parsing script.
+- CI runs Detekt and Lint with `--continue` so every module's report is produced even when one
+  module fails, then runs `mergeSarifReports` and uploads the single merged file via
+  `github/codeql-action/upload-sarif`, which shows results as PR annotations and in the repo's
+  Security > Code scanning tab.
 
 ## When Adding a New Plugin
 1. Create implementation class in `src/main/kotlin/sk/styk/martin/apkanalyzer/`

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -61,6 +61,10 @@ gradlePlugin {
             id = "apkanalyzer.detekt"
             implementationClass = "sk.styk.martin.apkanalyzer.DetektPlugin"
         }
+        register("apkanalyzer.sarif-merge") {
+            id = "apkanalyzer.sarif-merge"
+            implementationClass = "sk.styk.martin.apkanalyzer.SarifMergePlugin"
+        }
         register("apkanalyzer.compose") {
             id = "apkanalyzer.compose"
             implementationClass = "sk.styk.martin.apkanalyzer.ComposePlugin"

--- a/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/SarifMergePlugin.kt
+++ b/build-logic/convention/src/main/kotlin/sk/styk/martin/apkanalyzer/SarifMergePlugin.kt
@@ -1,0 +1,32 @@
+package sk.styk.martin.apkanalyzer
+
+import dev.detekt.gradle.report.ReportMergeTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.register
+
+class SarifMergePlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            require(this == rootProject) {
+                "apkanalyzer.sarif-merge must be applied to the root project."
+            }
+
+            tasks.register<ReportMergeTask>("mergeSarifReports") {
+                input.from(
+                    subprojects.map { module ->
+                        module.fileTree(module.layout.buildDirectory) {
+                            include("reports/detekt/*.sarif", "reports/lint-results-*.sarif")
+                        }
+                    },
+                )
+                input.from(
+                    fileTree(layout.projectDirectory.dir("build-logic")) {
+                        include("**/build/reports/detekt/*.sarif")
+                    },
+                )
+                output.set(layout.buildDirectory.file("reports/merged.sarif"))
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.apkanalyzer.agent.context)
     alias(libs.plugins.apkanalyzer.spotless)
+    alias(libs.plugins.apkanalyzer.sarif.merge)
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.compose.compiler) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,6 +117,7 @@ apkanalyzer-feature-impl = { id = "apkanalyzer.feature.impl" }
 apkanalyzer-hilt = { id = "apkanalyzer.hilt" }
 apkanalyzer-spotless = { id = "apkanalyzer.spotless" }
 apkanalyzer-detekt = { id = "apkanalyzer.detekt" }
+apkanalyzer-sarif-merge = { id = "apkanalyzer.sarif-merge" }
 apkanalyzer-compose = { id = "apkanalyzer.compose" }
 
 [bundles]


### PR DESCRIPTION
## Summary
- Both Detekt and Android Lint already emit a per-module SARIF report by default; CI only ever collected Detekt's.
- Adds a root-only `mergeSarifReports` task (`apkanalyzer.sarif-merge` convention plugin) backed by Detekt's own `ReportMergeTask`, which combines every module's Detekt and Lint SARIF reports into one file.
- Replaces the hand-rolled copy+jq merge script in CI with a single `./gradlew mergeSarifReports` call and one upload step covering both tools.
- Rebased on top of the CI parallelization work in #112.

## Test plan
- [x] `./gradlew mergeSarifReports` produces a merged SARIF with correct per-tool result counts (verified against the sum of all per-module reports: 121 Detekt + 70 Lint)
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew validateAgentContext`
- [x] Confirmed `--continue` in the CI verify step still fails the job on any Spotless/Detekt/Lint violation (only lets all three tools finish producing reports first)