### PR TITLE
Publish Gradle build scans from GitHub Actions

### DIFF
--- a/.github/workflows/agent-context.yml
+++ b/.github/workflows/agent-context.yml
@@ -59,6 +59,10 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -106,6 +110,10 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -59,6 +63,10 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
Gradle job summaries currently report that no Build Scan was published, leaving detailed diagnostics unavailable when investigating CI behavior.

This configures every `setup-gradle` invocation in CI, release, and agent-context workflows to publish scans to `scans.gradle.com` with explicit Terms of Service acceptance. Future job summaries will link directly to task timing, cache, dependency, and failure diagnostics.