### PR TITLE
Show full browse category descriptions

### DIFF
--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseScreen.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseScreen.kt
@@ -162,8 +162,6 @@ private fun DimensionCard(
                     text = summary.dimension.subtitle(),
                     style = AppTheme.typography.bodySmall,
                     color = AppTheme.colors.onSurfaceVariant,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
                 )
             }
             Spacer(modifier = Modifier.width(8.dp))


### PR DESCRIPTION
## Summary
- remove the two-line limit from browse category descriptions
- allow cards to grow so description text is never truncated

## Verification
- compiled `:feature:browse:impl`
- installed and checked the Browse screen on a connected Android device