### PR TITLE
Add shared UID and app category browse dimensions (FR-35/FR-42, FR-39/FR-43)

### DIFF
--- a/core/app-index/AGENTS.md
+++ b/core/app-index/AGENTS.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 Builds `attribute → apps` indexes across every installed app — target SDK, min SDK, install source,
-permission, and signing certificate (fingerprint, organization, country) — for the `feature:browse`
-"Browse by Attribute" screen (roadmap `CE-01`). A pure bucketing layer: it holds no `PackageManager`
-access of its own and reaches only two public `core:apps` repositories (`InstalledAppsRepository`,
-`AppSigningRepository`), never `analysis/` internals (`CertificateExtractor`, `InstallSourceResolver`)
-directly.
+permission, shared UID, app category, and signing certificate (fingerprint, organization, country) —
+for the `feature:browse` "Browse by Attribute" screen (roadmap `CE-01`). A pure bucketing layer: it
+holds no `PackageManager` access of its own and reaches only two public `core:apps` repositories
+(`InstalledAppsRepository`, `AppSigningRepository`), never `analysis/` internals
+(`CertificateExtractor`, `InstallSourceResolver`) directly.
 
 ## Package: `sk.styk.martin.apkanalyzer.core.appindex`
 
@@ -19,7 +19,7 @@ AppIndexRepository.kt / Impl  - Flow of AppIndexStatus; Impl combines InstalledA
                                 transform as private functions (one groupBy helper per dimension) —
                                 inlined rather than a separate object since it has exactly one caller
 model/
-  AppAttributeIndex.kt         - targetSdk / minSdk / installSource / permission / certificateFingerprint / certificateOrganization / certificateCountry buckets, each Map<value, List<packageName>>
+  AppAttributeIndex.kt         - targetSdk / minSdk / installSource / permission / certificateFingerprint / certificateOrganization / certificateCountry / sharedUserId / appCategory buckets, each Map<value, List<packageName>>
   AppIndexStatus.kt            - sealed: Loading | Data(index) - Loading before the first combined emission
 di/
   AppIndexModule.kt            - Hilt @Binds for AppIndexRepository
@@ -41,9 +41,15 @@ SharingStarted.Lazily, replay = 1)`, matching `AppSigningRepositoryImpl`'s reaso
 only matters once a real consumer (a browse screen) subscribes, and multiple simultaneous subscribers
 must not each redo it.
 
-## Dimensions, and why the first four are cheaper than the last three
+## Dimensions, and why the first six are cheaper than the last three
 
-`targetSdk`, `minSdk`, `installSource`, `permission` are all already on `InstalledApp` — no new query.
+`targetSdk`, `minSdk`, `installSource`, `permission`, `sharedUserId`, `appCategory` are all already on
+`InstalledApp` — no new query. `sharedUserId` is the one dimension that legitimately drops apps: only
+those declaring `android:sharedUserId` are indexed (`bySharedUserId` `mapNotNull`s the null case away),
+matching `byPermission`'s existing "no signal, no bucket" shape rather than inventing an "unshared"
+sentinel bucket that would just be most of the device. `appCategory` keeps `AppCategory.Undefined` as
+a real, groupable bucket instead, because most third-party apps genuinely declare no category and
+that absence is itself the fact worth counting.
 `certificateFingerprint`/`certificateOrganization`/`certificateCountry` come from
 `AppSigningRepository`, which runs a real X.509 parse, six digest computations, and a signature-verify
 per certificate — genuinely heavier, which is why that repository is `Lazily` shared (see

--- a/core/app-index/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appindex/AppIndexRepositoryImpl.kt
+++ b/core/app-index/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appindex/AppIndexRepositoryImpl.kt
@@ -43,6 +43,8 @@ internal class AppIndexRepositoryImpl @Inject constructor(
         certificateFingerprint = apps.byCertificate(signing) { it.certificateHashSha256 },
         certificateOrganization = apps.byCertificate(signing) { it.subject.organization },
         certificateCountry = apps.byCertificate(signing) { it.subject.country },
+        sharedUserId = apps.bySharedUserId(),
+        appCategory = apps.byAppCategory(),
     )
 
     private fun List<InstalledApp>.byTargetSdk() = groupBy(InstalledApp::targetSdk, InstalledApp::packageName)
@@ -53,6 +55,11 @@ internal class AppIndexRepositoryImpl @Inject constructor(
 
     private fun List<InstalledApp>.byPermission() = flatMap { app -> app.requestedPermissions.map { it to app.packageName } }
         .groupBy({ it.first }, { it.second })
+
+    private fun List<InstalledApp>.bySharedUserId() = mapNotNull { app -> app.sharedUserId?.let { it to app.packageName } }
+        .groupBy({ it.first }, { it.second })
+
+    private fun List<InstalledApp>.byAppCategory() = groupBy(InstalledApp::category, InstalledApp::packageName)
 
     private fun <T> List<InstalledApp>.byCertificate(signing: Map<PackageName, AppSigning>, key: (Certificate) -> T): Map<T, List<PackageName>> =
         flatMap { app -> signing[app.packageName]?.currentCertificates.orEmpty().map { key(it) to app.packageName } }

--- a/core/app-index/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appindex/model/AppAttributeIndex.kt
+++ b/core/app-index/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appindex/model/AppAttributeIndex.kt
@@ -1,5 +1,6 @@
 package sk.styk.martin.apkanalyzer.core.appindex.model
 
+import sk.styk.martin.apkanalyzer.core.apps.model.AppCategory
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 
@@ -11,4 +12,6 @@ data class AppAttributeIndex(
     val certificateFingerprint: Map<String, List<PackageName>>,
     val certificateOrganization: Map<String?, List<PackageName>>,
     val certificateCountry: Map<String?, List<PackageName>>,
+    val sharedUserId: Map<String, List<PackageName>>,
+    val appCategory: Map<AppCategory, List<PackageName>>,
 )

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -30,7 +30,9 @@ analysis/
   AnalysisUtils.kt                   - Shared analysis helpers, incl. permission protection decoding
 model/
   InstalledApp.kt         - Basic installed app info (packageName, name, sizes, times, source,
-                            targetSdk, minSdk)
+                            targetSdk, minSdk, sharedUserId, category)
+  AppCategory.kt          - `ApplicationInfo.category` int decoded to a domain enum; `Undefined` is
+                            the untagged case (most third-party apps), not an error
   AppDetail.kt            - Complete app detail (info, permissions, activities, services, etc.)
   AppInfo.kt              - Core app metadata, including public manifest security flags from `ApplicationInfo`
   Permission.kt           - Single permission: name plus `details`, which is null when the device

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -161,6 +161,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             allowsBackup = applicationInfo.hasFlag(ApplicationInfo.FLAG_ALLOW_BACKUP),
             usesCleartextTraffic = applicationInfo.hasFlag(ApplicationInfo.FLAG_USES_CLEARTEXT_TRAFFIC),
             uid = applicationInfo?.uid,
+            sharedUserId = packageInfo.sharedUserId,
             description = applicationInfo?.loadDescription(packageManager)?.toString(),
             apkDirectory = applicationInfo?.sourceDir,
             dataDirectory = applicationInfo?.dataDir,

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package sk.styk.martin.apkanalyzer.core.apps
 
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import kotlinx.coroutines.CoroutineScope
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import sk.styk.martin.apkanalyzer.core.apps.analysis.InstallSourceResolver
+import sk.styk.martin.apkanalyzer.core.apps.analysis.resolveAppCategory
 import sk.styk.martin.apkanalyzer.core.apps.model.InstalledApp
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
@@ -81,6 +83,8 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
             installTime = Instant.ofEpochMilli(firstInstallTime),
             lastUpdateTime = Instant.ofEpochMilli(lastUpdateTime),
             requestedPermissions = requestedPermissions?.toList().orEmpty(),
+            sharedUserId = sharedUserId,
+            category = resolveAppCategory(appInfo?.category ?: ApplicationInfo.CATEGORY_UNDEFINED),
         )
     }
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/AnalysisUtils.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/AnalysisUtils.kt
@@ -1,8 +1,10 @@
 package sk.styk.martin.apkanalyzer.core.apps.analysis
 
+import android.content.pm.ApplicationInfo
 import android.content.pm.PathPermission
 import android.content.pm.PermissionInfo
 import android.os.PatternMatcher
+import sk.styk.martin.apkanalyzer.core.apps.model.AppCategory
 import sk.styk.martin.apkanalyzer.core.apps.model.ProtectionFlag
 import sk.styk.martin.apkanalyzer.core.apps.model.ProtectionLevel
 import sk.styk.martin.apkanalyzer.core.apps.model.ProviderPathMatchType
@@ -49,4 +51,17 @@ private fun resolvePathMatchType(type: Int): ProviderPathMatchType = when (type)
     PatternMatcher.PATTERN_ADVANCED_GLOB -> ProviderPathMatchType.AdvancedGlob
     PatternMatcher.PATTERN_SUFFIX -> ProviderPathMatchType.Suffix
     else -> ProviderPathMatchType.Literal
+}
+
+internal fun resolveAppCategory(category: Int): AppCategory = when (category) {
+    ApplicationInfo.CATEGORY_GAME -> AppCategory.Game
+    ApplicationInfo.CATEGORY_AUDIO -> AppCategory.Audio
+    ApplicationInfo.CATEGORY_VIDEO -> AppCategory.Video
+    ApplicationInfo.CATEGORY_IMAGE -> AppCategory.Image
+    ApplicationInfo.CATEGORY_SOCIAL -> AppCategory.Social
+    ApplicationInfo.CATEGORY_NEWS -> AppCategory.News
+    ApplicationInfo.CATEGORY_MAPS -> AppCategory.Maps
+    ApplicationInfo.CATEGORY_PRODUCTIVITY -> AppCategory.Productivity
+    ApplicationInfo.CATEGORY_ACCESSIBILITY -> AppCategory.Accessibility
+    else -> AppCategory.Undefined
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/AppCategory.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/AppCategory.kt
@@ -1,0 +1,14 @@
+package sk.styk.martin.apkanalyzer.core.apps.model
+
+enum class AppCategory {
+    Undefined,
+    Game,
+    Audio,
+    Video,
+    Image,
+    Social,
+    News,
+    Maps,
+    Productivity,
+    Accessibility,
+}

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/AppInfo.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/AppInfo.kt
@@ -17,6 +17,7 @@ data class AppInfo(
     val allowsBackup: Boolean = false,
     val usesCleartextTraffic: Boolean = false,
     val uid: Int? = null,
+    val sharedUserId: String? = null,
     val description: String? = null,
     val source: AppSource = AppSource.Unknown,
     val apkDirectory: String? = null,

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/InstalledApp.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/InstalledApp.kt
@@ -20,4 +20,6 @@ data class InstalledApp(
     val requestedPermissions: List<String> = emptyList(),
     val totalSize: AppSize? = null,
     val lastUsedTime: Instant? = null,
+    val sharedUserId: String? = null,
+    val category: AppCategory = AppCategory.Undefined,
 )

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -79,8 +79,8 @@ flag (`GET_CONFIGURATIONS`) with no other `core:apps` consumer yet, unlike certi
 | FR-09 | ↳ dimension: signing certificate    | Done    | Bucketed by signer organization (`certificateOrganization`); fingerprint and country stay indexed in `core:app-index` but are not separate browse dimensions in this pass |
 | FR-40 | ↳ dimension: target SDK / min SDK   | Done    | Bucket label from `SdkVersionResolver` (`core:apps`), e.g. "Android 14"; raw API level shown as the identifier |
 | FR-41 | ↳ dimension: install source         | Done    | Google Play / System / Unknown, three buckets                                             |
-| FR-42 | ↳ dimension: shared UID             | Todo    | Needs `FR-35`                                                                             |
-| FR-43 | ↳ dimension: app category           | Todo    | Needs `FR-39`                                                                             |
+| FR-42 | ↳ dimension: shared UID             | Done    | `BrowseDimension.SharedUserId`; only apps declaring `android:sharedUserId` are bucketed, no "unshared" sentinel |
+| FR-43 | ↳ dimension: app category           | Done    | `BrowseDimension.AppCategory`; `AppCategory.Undefined` is a real bucket, not dropped               |
 | CE-06 | "Also signed with this certificate" | Backlog | The other installed apps sharing this signer, listed on the app detail certificate screen. Data is already extracted; it needs a fingerprint-keyed lookup instead of `CE-05`'s organization-keyed bucket. **Revisit when that lookup is built** — see [features/app-detail.md](features/app-detail.md#deferred) |
 
 **Module consolidation: done.** `feature:permissions` and `feature:statistics` — both placeholder
@@ -153,11 +153,11 @@ doing in R0 rather than later.
 | FR-32 | Manifest security flags           | Done   | `debuggable`, `allowBackup`, and `usesCleartextTraffic` from public `ApplicationInfo`; custom network config deferred |
 | FR-33 | Native libraries / ABIs           | Todo   | Was in the Pro backlog; it's raw data, so free. Also the cheapest tracker-detection signal (`TR-03`) |
 | FR-34 | Split APKs / config splits        | Todo   | Most modern installs are splits; APK size and "what's installed" are both wrong without it           |
-| FR-35 | Shared UID group                  | Todo   | Security-relevant, one field, currently unread                                                       |
+| FR-35 | Shared UID group                  | Done   | `InstalledApp.sharedUserId` from `PackageInfo.sharedUserId`; feeds the `FR-42` browse dimension       |
 | FR-36 | Signing scheme version & signers  | Todo   | v1–v4, multi-signer, rotation history — feeds `CE-02` / `CE-03`                                       |
 | FR-37 | Storage breakdown                 | Todo   | `StorageStats` already gives app/data/cache; only the total is used                                  |
 | FR-38 | Full install-source chain         | Todo   | Only `installingPackageName` is read; initiating + originating package are what actually distinguish a sideload from a store install |
-| FR-39 | App category                      | Todo   | One field; unlocks the `FR-43` browse dimension                                                      |
+| FR-39 | App category                      | Done   | `InstalledApp.category` (`AppCategory` enum) from `ApplicationInfo.category`; feeds the `FR-43` browse dimension |
 | EX-07 | Component intent filters          | Done   | What an exported component actually responds to. Backs `ComponentIntentFilterKey` / `IntentFiltersScreen` in the Components screen (`FR-13`) and is available for `RI-03`. `EX-08` is the remaining half `FR-17` needs before exposure becomes a hub finding |
 | EX-08 | Content-provider path permissions | Done   | `<path-permission>` read/write grants per path, read straight off `ProviderInfo.pathPermissions` (already fetched via `GET_PROVIDERS`, no manifest parsing needed). Feeds the Components screen's `Unprotected` filter and item sheet; hub interpretation still needs a rule, tracked under `RI-03` |
 | FR-44 | Declared `<uses-library>` entries  | Todo   | Name and `android:required`, from the manifest for APK files and `sharedLibraryFiles` for installed apps. The platform-library half of device requirements — `org.apache.http.legacy` on a modern app is a signal the hardware list cannot give |

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoScreen.kt
@@ -145,6 +145,15 @@ private fun LoadedContent(
                     onCopy = onCopy,
                 )
             }
+            state.sharedUserId?.let { value ->
+                InfoRowItem(
+                    label = stringResource(R.string.general_info_shared_user_id),
+                    value = value,
+                    rationale = stringResource(R.string.general_info_rationale_shared_user_id),
+                    onShowRationale = { rationaleRow = it },
+                    onCopy = onCopy,
+                )
+            }
             state.description?.let { value ->
                 InfoRowItem(
                     label = stringResource(R.string.general_info_description),
@@ -441,6 +450,7 @@ private fun sampleGeneralInfoState() = GeneralInfoState.Loaded(
     packageName = PackageName("com.spotify.music"),
     processName = "com.spotify.music",
     uid = 10234,
+    sharedUserId = null,
     description = null,
     versionName = "8.9.42.575",
     versionCode = 120400567,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoState.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoState.kt
@@ -15,6 +15,7 @@ sealed interface GeneralInfoState {
         val packageName: PackageName,
         val processName: String?,
         val uid: Int?,
+        val sharedUserId: String?,
         val description: String?,
         val versionName: String?,
         val versionCode: Long,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoViewModel.kt
@@ -76,6 +76,7 @@ private fun AppDetail.toGeneralInfoState() = GeneralInfoState.Loaded(
     packageName = info.packageName,
     processName = info.processName,
     uid = info.uid,
+    sharedUserId = info.sharedUserId,
     description = info.description,
     versionName = info.versionName,
     versionCode = info.versionCode,

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -194,6 +194,7 @@
     <string name="general_info_package_name">Package Name</string>
     <string name="general_info_process_name">Process Name</string>
     <string name="general_info_uid">UID</string>
+    <string name="general_info_shared_user_id">Shared identity</string>
     <string name="general_info_description">Description</string>
     <string name="general_info_version_name">Version Name</string>
     <string name="general_info_version_code">Version Code</string>
@@ -224,6 +225,7 @@
     <string name="general_info_rationale_package_name">The unique identifier for this app on the device. No two apps can share the same package name.</string>
     <string name="general_info_rationale_process_name">The name of the operating system process the app runs in. By default, it matches the package name.</string>
     <string name="general_info_rationale_uid">The unique identifier assigned to this app by the Android system. It determines the app\'s access to system resources and file permissions.</string>
+    <string name="general_info_rationale_shared_user_id">This app declares that it runs under a shared identity with other apps signed by the same key. Apps sharing this identity can access each other\'s data and permissions as if they were one app.</string>
     <string name="general_info_rationale_description">An optional summary provided by the app developer in the manifest.</string>
     <string name="general_info_rationale_version_name">The human-readable version string displayed to users, such as \"2.5.1\" or \"Beta 3\".</string>
     <string name="general_info_rationale_version_code">An internal integer that increases with every release. The system uses it to determine whether one version is newer than another.</string>

--- a/feature/browse/AGENTS.md
+++ b/feature/browse/AGENTS.md
@@ -25,7 +25,7 @@ object BrowseNavKey : NavKey
 
 ```
 model/
-  BrowseDimension.kt        - @Serializable enum: Permission, SigningCertificate, TargetSdk, MinSdk, InstallSource
+  BrowseDimension.kt        - @Serializable enum: Permission, SigningCertificate, TargetSdk, MinSdk, InstallSource, SharedUserId, AppCategory
 domain/
   BrowseBuckets.kt           - AppAttributeIndex.bucketsFor(dimension): Map<String, List<PackageName>>,
                                 normalizing every dimension's key type (Int, AppSource, String?) to String.
@@ -33,10 +33,14 @@ domain/
   BrowseDimensionLabeler.kt  - @Inject; resolves a dimension+key pair to a friendly label and an
                                 optional raw identifier. Wraps PermissionLabelProvider (core:app-permissions)
                                 and SdkVersionResolver (core:apps) for the two dimensions that need a
-                                real lookup; the enum-backed dimensions (install source, unknown signer)
-                                resolve directly from this module's own strings.xml via Context.getString
-                                — deliberately not through Compose stringResource, since this runs outside
-                                a @Composable in the ViewModel/domain layer
+                                real lookup; the enum-backed dimensions (install source, app category,
+                                unknown signer) resolve directly from this module's own strings.xml via
+                                Context.getString — deliberately not through Compose stringResource,
+                                since this runs outside a @Composable in the ViewModel/domain layer.
+                                Shared UID has no friendlier form than the declared string itself, so its
+                                label is the raw key with no lookup at all. Each enum-backed dimension's
+                                mapping is a separate private function (see `categoryLabel`), not one
+                                growing `when` in `label()` — Detekt's cyclomatic-complexity limit is why
 BrowseDimensionResources.kt  - Composable-only per-dimension icon/title/subtitle, shared by all three screens
 BrowseState.kt / BrowseAction.kt / BrowseEvent.kt / BrowseViewModel.kt / BrowseScreen.kt
                               - Hub: dimension cards with a top-labels preview row and an option count,

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseDimensionResources.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/BrowseDimensionResources.kt
@@ -11,6 +11,8 @@ internal fun BrowseDimension.icon(): ImageVector = when (this) {
     BrowseDimension.SigningCertificate -> ApkAnalyzerIcons.Fingerprint
     BrowseDimension.TargetSdk, BrowseDimension.MinSdk -> ApkAnalyzerIcons.Android
     BrowseDimension.InstallSource -> ApkAnalyzerIcons.Folder
+    BrowseDimension.SharedUserId -> ApkAnalyzerIcons.Group
+    BrowseDimension.AppCategory -> ApkAnalyzerIcons.Widgets
 }
 
 @Composable
@@ -21,6 +23,8 @@ internal fun BrowseDimension.title(): String = stringResource(
         BrowseDimension.TargetSdk -> R.string.browse_dimension_target_sdk_title
         BrowseDimension.MinSdk -> R.string.browse_dimension_min_sdk_title
         BrowseDimension.InstallSource -> R.string.browse_dimension_install_source_title
+        BrowseDimension.SharedUserId -> R.string.browse_dimension_shared_user_id_title
+        BrowseDimension.AppCategory -> R.string.browse_dimension_app_category_title
     },
 )
 
@@ -32,5 +36,7 @@ internal fun BrowseDimension.subtitle(): String = stringResource(
         BrowseDimension.TargetSdk -> R.string.browse_dimension_target_sdk_subtitle
         BrowseDimension.MinSdk -> R.string.browse_dimension_min_sdk_subtitle
         BrowseDimension.InstallSource -> R.string.browse_dimension_install_source_subtitle
+        BrowseDimension.SharedUserId -> R.string.browse_dimension_shared_user_id_subtitle
+        BrowseDimension.AppCategory -> R.string.browse_dimension_app_category_subtitle
     },
 )

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseBuckets.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseBuckets.kt
@@ -16,6 +16,10 @@ internal fun AppAttributeIndex.bucketsFor(dimension: BrowseDimension, subKey: St
 
     BrowseDimension.InstallSource -> installSource.mapKeys { it.key.name }
 
+    BrowseDimension.SharedUserId -> sharedUserId
+
+    BrowseDimension.AppCategory -> appCategory.mapKeys { it.key.name }
+
     BrowseDimension.SigningCertificate -> when (subKey) {
         CERTIFICATE_ORGANIZATION -> certificateOrganization.mapKeys { it.key ?: UNKNOWN_SIGNER_KEY }
         CERTIFICATE_COUNTRY -> certificateCountry.mapKeys { it.key ?: UNKNOWN_COUNTRY_KEY }

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseDimensionLabeler.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseDimensionLabeler.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import sk.styk.martin.apkanalyzer.core.apppermissions.PermissionLabelProvider
 import sk.styk.martin.apkanalyzer.core.apps.analysis.SdkVersionResolver
+import sk.styk.martin.apkanalyzer.core.apps.model.AppCategory
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.feature.browse.impl.R
 import sk.styk.martin.apkanalyzer.feature.browse.impl.model.BrowseDimension
@@ -34,6 +35,10 @@ internal class BrowseDimensionLabeler @Inject constructor(
             else -> context.getString(R.string.browse_source_unknown)
         }
 
+        BrowseDimension.SharedUserId -> key
+
+        BrowseDimension.AppCategory -> categoryLabel(AppCategory.valueOf(key))
+
         BrowseDimension.SigningCertificate -> when (subKey) {
             CERTIFICATE_ORGANIZATION -> key.takeUnless { it == UNKNOWN_SIGNER_KEY } ?: context.getString(R.string.browse_signer_unknown)
 
@@ -55,6 +60,10 @@ internal class BrowseDimensionLabeler @Inject constructor(
 
         BrowseDimension.InstallSource -> null
 
+        BrowseDimension.SharedUserId -> null
+
+        BrowseDimension.AppCategory -> null
+
         BrowseDimension.SigningCertificate -> when (subKey) {
             CERTIFICATE_ORGANIZATION -> null
             CERTIFICATE_COUNTRY -> key.takeUnless { it == UNKNOWN_COUNTRY_KEY }
@@ -65,6 +74,19 @@ internal class BrowseDimensionLabeler @Inject constructor(
     private fun countryLabel(countryCode: String): String {
         val displayName = runCatching { Locale.Builder().setRegion(countryCode).build().displayCountry }.getOrNull()
         return displayName?.takeIf { it.isNotBlank() && !it.equals(countryCode, ignoreCase = true) } ?: countryCode
+    }
+
+    private fun categoryLabel(category: AppCategory): String = when (category) {
+        AppCategory.Undefined -> context.getString(R.string.browse_category_undefined)
+        AppCategory.Game -> context.getString(R.string.browse_category_game)
+        AppCategory.Audio -> context.getString(R.string.browse_category_audio)
+        AppCategory.Video -> context.getString(R.string.browse_category_video)
+        AppCategory.Image -> context.getString(R.string.browse_category_image)
+        AppCategory.Social -> context.getString(R.string.browse_category_social)
+        AppCategory.News -> context.getString(R.string.browse_category_news)
+        AppCategory.Maps -> context.getString(R.string.browse_category_maps)
+        AppCategory.Productivity -> context.getString(R.string.browse_category_productivity)
+        AppCategory.Accessibility -> context.getString(R.string.browse_category_accessibility)
     }
 }
 

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseSubAttributes.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/domain/BrowseSubAttributes.kt
@@ -22,5 +22,7 @@ internal fun BrowseDimension.subAttributes(): ImmutableList<BrowseSubAttribute> 
     BrowseDimension.TargetSdk,
     BrowseDimension.MinSdk,
     BrowseDimension.InstallSource,
+    BrowseDimension.SharedUserId,
+    BrowseDimension.AppCategory,
     -> persistentListOf()
 }

--- a/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/model/BrowseDimension.kt
+++ b/feature/browse/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/browse/impl/model/BrowseDimension.kt
@@ -9,4 +9,6 @@ internal enum class BrowseDimension {
     TargetSdk,
     MinSdk,
     InstallSource,
+    SharedUserId,
+    AppCategory,
 }

--- a/feature/browse/impl/src/main/res/values/strings.xml
+++ b/feature/browse/impl/src/main/res/values/strings.xml
@@ -17,6 +17,10 @@
     <string name="browse_dimension_min_sdk_subtitle">See the oldest Android version each app still supports</string>
     <string name="browse_dimension_install_source_title">Install source</string>
     <string name="browse_dimension_install_source_subtitle">See where each app came from</string>
+    <string name="browse_dimension_shared_user_id_title">Shared identity</string>
+    <string name="browse_dimension_shared_user_id_subtitle">Find apps that run under the same device identity and can access each other\'s data</string>
+    <string name="browse_dimension_app_category_title">App category</string>
+    <string name="browse_dimension_app_category_subtitle">See what kind of app each one declares itself to be</string>
     <plurals name="browse_dimension_option_count">
         <item quantity="one">%1$d option</item>
         <item quantity="other">%1$d options</item>
@@ -29,6 +33,16 @@
     <string name="browse_source_unknown">Unknown</string>
     <string name="browse_signer_unknown">Unknown signer</string>
     <string name="browse_country_unknown">Unknown country</string>
+    <string name="browse_category_undefined">Uncategorized</string>
+    <string name="browse_category_game">Games</string>
+    <string name="browse_category_audio">Audio</string>
+    <string name="browse_category_video">Video</string>
+    <string name="browse_category_image">Image</string>
+    <string name="browse_category_social">Social</string>
+    <string name="browse_category_news">News &amp; magazines</string>
+    <string name="browse_category_maps">Maps &amp; navigation</string>
+    <string name="browse_category_productivity">Productivity</string>
+    <string name="browse_category_accessibility">Accessibility</string>
 
     <string name="browse_sub_attribute_sheet_title">Group by</string>
     <string name="browse_certificate_attribute_fingerprint">Identity (SHA-256)</string>


### PR DESCRIPTION
## Summary
- `PackageInfo.sharedUserId` and `ApplicationInfo.category` were both sitting unread on data `InstalledAppsRepositoryImpl` already fetches — no new query, no new flag.
- New `AppCategory` enum decodes the `ApplicationInfo.category` int (`core/apps/analysis/AnalysisUtils.kt`).
- `core:app-index` buckets both: `sharedUserId` drops apps that declare none (same shape as the existing `permission` dimension — no "unshared" catch-all bucket for the ~460 apps that don't share); `appCategory` keeps `Undefined` as a real, groupable bucket since most third-party apps genuinely declare no category.
- `feature:browse` gets two new `BrowseDimension` cases end to end — buckets, labels, icons (`Group`, `Widgets`, added to `ApkAnalyzerIcons`), titles/subtitles, strings. `categoryLabel()` is split out of `BrowseDimensionLabeler.label()` to stay under Detekt's cyclomatic-complexity limit.
- Also adds the declared shared UID to the app detail General Info screen as a "Shared identity" row (next to the existing numeric UID row) — the UID alone doesn't explain *why* an app might intentionally share identity with another app.
- Updates `core/app-index/AGENTS.md`, `core/apps/AGENTS.md`, `feature/browse/AGENTS.md`, and `docs/product/roadmap.md` (`FR-35`, `FR-39`, `FR-42`, `FR-43` → Done).

## Test plan
- [x] Compiles clean across `core:apps`, `core:app-index`, `core:ui-library`, `feature:browse:impl`, `feature:app-detail:impl`
- [x] `spotlessApply`
- [x] `detektDebug` on all touched modules (only pre-existing-style advisory `LongMethod`/`MagicNumber`, no blocking findings)
- [x] Verified on a physical device: both Browse dimension cards render with real data (Shared identity: 21 options incl. `android.uid.system`/`android.uid.phone`; App category: 8 options incl. Productivity/Social/Uncategorized), and the General Info "Shared identity" row shows `android.uid.system` for the Android System package