### PR TITLE
Fix Android plural resource lint findings

### DIFF
--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
@@ -797,9 +797,17 @@ private fun PermissionsSection(
             Text(
                 text = if (state.dangerousPermissionsCount > 0) {
                     stringResource(
-                        R.string.app_detail_permissions_counts,
-                        state.totalPermissionsCount,
-                        state.dangerousPermissionsCount,
+                        R.string.app_detail_count_pair,
+                        pluralStringResource(
+                            R.plurals.app_detail_permissions_requested_count,
+                            state.totalPermissionsCount,
+                            state.totalPermissionsCount,
+                        ),
+                        pluralStringResource(
+                            R.plurals.app_detail_permissions_sensitive_count,
+                            state.dangerousPermissionsCount,
+                            state.dangerousPermissionsCount,
+                        ),
                     )
                 } else {
                     pluralStringResource(
@@ -945,9 +953,17 @@ private fun RequirementsSection(
         Spacer(modifier = Modifier.height(6.dp))
         Text(
             text = stringResource(
-                R.string.app_detail_features_counts,
-                state.requiredFeaturesCount,
-                state.optionalFeaturesCount,
+                R.string.app_detail_count_pair,
+                pluralStringResource(
+                    R.plurals.app_detail_features_required_count,
+                    state.requiredFeaturesCount,
+                    state.requiredFeaturesCount,
+                ),
+                pluralStringResource(
+                    R.plurals.app_detail_features_optional_count,
+                    state.optionalFeaturesCount,
+                    state.optionalFeaturesCount,
+                ),
             ),
             style = AppTheme.typography.bodySmall,
             color = AppTheme.colors.onSurfaceVariant,

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <string name="content_description_back">Back</string>
     <string name="app_detail_title">App Detail</string>
     <string name="app_detail_system_app">System Application</string>
@@ -63,7 +63,15 @@
         <item quantity="one">%1$d permission requested in total</item>
         <item quantity="other">%1$d permissions requested in total</item>
     </plurals>
-    <string name="app_detail_permissions_counts" tools:ignore="PluralsCandidate">%1$d requested · %2$d sensitive</string>
+    <plurals name="app_detail_permissions_requested_count">
+        <item quantity="one">%d permission requested</item>
+        <item quantity="other">%d permissions requested</item>
+    </plurals>
+    <plurals name="app_detail_permissions_sensitive_count">
+        <item quantity="one">%d sensitive permission</item>
+        <item quantity="other">%d sensitive permissions</item>
+    </plurals>
+    <string name="app_detail_count_pair">%1$s · %2$s</string>
     <string name="app_detail_components_section">Components</string>
     <string name="app_detail_activities">Activities</string>
     <string name="app_detail_services">Services</string>
@@ -73,7 +81,14 @@
     <string name="app_detail_certificates_count">Certificates</string>
     <string name="app_detail_view_details">View Details</string>
     <string name="app_detail_features_section">Device requirements</string>
-    <string name="app_detail_features_counts" tools:ignore="PluralsCandidate">%1$d required · %2$d optional</string>
+    <plurals name="app_detail_features_required_count">
+        <item quantity="one">%d required feature</item>
+        <item quantity="other">%d required features</item>
+    </plurals>
+    <plurals name="app_detail_features_optional_count">
+        <item quantity="one">%d optional feature</item>
+        <item quantity="other">%d optional features</item>
+    </plurals>
     <string name="app_detail_features_all_met">This device meets everything the app requires</string>
     <string name="app_detail_features_none">This app declares no device requirements</string>
     <plurals name="app_detail_features_unmet">

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="content_description_back">Back</string>
     <string name="app_detail_title">App Detail</string>
     <string name="app_detail_system_app">System Application</string>
@@ -63,7 +63,7 @@
         <item quantity="one">%1$d permission requested in total</item>
         <item quantity="other">%1$d permissions requested in total</item>
     </plurals>
-    <string name="app_detail_permissions_counts">%1$d requested · %2$d sensitive</string>
+    <string name="app_detail_permissions_counts" tools:ignore="PluralsCandidate">%1$d requested · %2$d sensitive</string>
     <string name="app_detail_components_section">Components</string>
     <string name="app_detail_activities">Activities</string>
     <string name="app_detail_services">Services</string>
@@ -73,7 +73,7 @@
     <string name="app_detail_certificates_count">Certificates</string>
     <string name="app_detail_view_details">View Details</string>
     <string name="app_detail_features_section">Device requirements</string>
-    <string name="app_detail_features_counts">%1$d required · %2$d optional</string>
+    <string name="app_detail_features_counts" tools:ignore="PluralsCandidate">%1$d required · %2$d optional</string>
     <string name="app_detail_features_all_met">This device meets everything the app requires</string>
     <string name="app_detail_features_none">This app declares no device requirements</string>
     <plurals name="app_detail_features_unmet">

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/filter/FilterScreen.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/filter/FilterScreen.kt
@@ -662,10 +662,15 @@ private fun AppSource.displayName(): String = when (this) {
 
 @Composable
 private fun UnusedAppsPeriod.label(): String = when (this) {
-    UnusedAppsPeriod.ONE_MONTH -> pluralStringResource(R.plurals.filter_unused_months_count, 1, 1)
-    UnusedAppsPeriod.TWO_MONTHS -> pluralStringResource(R.plurals.filter_unused_months_count, 2, 2)
-    UnusedAppsPeriod.THREE_MONTHS -> pluralStringResource(R.plurals.filter_unused_months_count, 3, 3)
-    UnusedAppsPeriod.SIX_MONTHS -> pluralStringResource(R.plurals.filter_unused_months_count, 6, 6)
+    UnusedAppsPeriod.ONE_MONTH,
+    UnusedAppsPeriod.TWO_MONTHS,
+    UnusedAppsPeriod.THREE_MONTHS,
+    UnusedAppsPeriod.SIX_MONTHS,
+    -> {
+        val monthCount = days / UnusedAppsPeriod.ONE_MONTH.days
+        pluralStringResource(R.plurals.filter_unused_months_count, monthCount, monthCount)
+    }
+
     UnusedAppsPeriod.ONE_YEAR -> stringResource(R.string.filter_unused_year)
 }
 

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/filter/FilterScreen.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/filter/FilterScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -661,10 +662,10 @@ private fun AppSource.displayName(): String = when (this) {
 
 @Composable
 private fun UnusedAppsPeriod.label(): String = when (this) {
-    UnusedAppsPeriod.ONE_MONTH -> stringResource(R.string.filter_unused_months_count, 1)
-    UnusedAppsPeriod.TWO_MONTHS -> stringResource(R.string.filter_unused_months_count, 2)
-    UnusedAppsPeriod.THREE_MONTHS -> stringResource(R.string.filter_unused_months_count, 3)
-    UnusedAppsPeriod.SIX_MONTHS -> stringResource(R.string.filter_unused_months_count, 6)
+    UnusedAppsPeriod.ONE_MONTH -> pluralStringResource(R.plurals.filter_unused_months_count, 1, 1)
+    UnusedAppsPeriod.TWO_MONTHS -> pluralStringResource(R.plurals.filter_unused_months_count, 2, 2)
+    UnusedAppsPeriod.THREE_MONTHS -> pluralStringResource(R.plurals.filter_unused_months_count, 3, 3)
+    UnusedAppsPeriod.SIX_MONTHS -> pluralStringResource(R.plurals.filter_unused_months_count, 6, 6)
     UnusedAppsPeriod.ONE_YEAR -> stringResource(R.string.filter_unused_year)
 }
 

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/filter/permission/PermissionFilterScreen.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/filter/permission/PermissionFilterScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -125,8 +126,14 @@ private fun PermissionFilterContent(
         val activePresetCount = state.presets.count { it.isSelected }
         val presetsLabel = when (activePresetCount) {
             0 -> stringResource(R.string.filter_permissions_chip_presets)
+
             1 -> state.presets.first { it.isSelected }.preset.displayLabel()
-            else -> stringResource(R.string.filter_permissions_chip_presets_count, activePresetCount)
+
+            else -> pluralStringResource(
+                R.plurals.filter_permissions_chip_presets_count,
+                activePresetCount,
+                activePresetCount,
+            )
         }
 
         Row(

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/search/AppSearchScreen.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/search/AppSearchScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -260,7 +261,7 @@ private fun EmptySearchContent(totalAppCount: Int, modifier: Modifier = Modifier
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = stringResource(R.string.search_apps_empty, totalAppCount),
+            text = pluralStringResource(R.plurals.search_apps_empty, totalAppCount, totalAppCount),
             style = AppTheme.typography.bodyMedium,
             color = AppTheme.colors.onSurfaceVariant,
         )

--- a/feature/apps/impl/src/main/res/values/strings.xml
+++ b/feature/apps/impl/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="content_description_back">Back</string>
     <string name="content_description_settings">Settings</string>
     <string name="content_description_analyze_apk">Analyze APK file</string>
@@ -16,8 +16,14 @@
     <string name="sort_last_used">Last Used</string>
     <string name="sort_bottom_sheet_title">Sort by</string>
     <string name="search_apps_hint">Search apps</string>
-    <string name="search_apps_placeholder">Search %1$d apps…</string>
-    <string name="search_apps_matches">%d matches found</string>
+    <plurals name="search_apps_placeholder">
+        <item quantity="one">Search %1$d app…</item>
+        <item quantity="other">Search %1$d apps…</item>
+    </plurals>
+    <plurals name="search_apps_matches">
+        <item quantity="one">%d match found</item>
+        <item quantity="other">%d matches found</item>
+    </plurals>
     <string name="filter">Filter</string>
     <string name="preinstalled">Preinstalled</string>
     <string name="never">Never</string>
@@ -34,7 +40,10 @@
     <string name="installed_apps">Installed apps</string>
     <string name="installed_apps_count">Installed apps (%1$d)</string>
     <string name="recently_viewed">Recently viewed</string>
-    <string name="search_apps_empty">Search %1$d installed apps</string>
+    <plurals name="search_apps_empty">
+        <item quantity="one">Search %1$d installed app</item>
+        <item quantity="other">Search %1$d installed apps</item>
+    </plurals>
     <string name="search_apps_no_results">No results for \"%1$s\"</string>
     <string name="search_history_title">Recent searches</string>
     <string name="search_history_clear">Clear</string>
@@ -62,8 +71,14 @@
     <string name="filter_unused_section">Unused Apps</string>
     <string name="filter_unused_locked_description">Find apps gathering dust. Grant usage access to see which apps you haven\'t opened recently.</string>
     <string name="filter_unused_grant_access">Grant access</string>
-    <string name="filter_unused_days_count">%d days</string>
-    <string name="filter_unused_months_count">%d months</string>
+    <plurals name="filter_unused_days_count">
+        <item quantity="one">%d day</item>
+        <item quantity="other">%d days</item>
+    </plurals>
+    <plurals name="filter_unused_months_count">
+        <item quantity="one">%d month</item>
+        <item quantity="other">%d months</item>
+    </plurals>
     <string name="filter_unused_year">1 year</string>
     <string name="quick_filter_permission_usage_title">Usage access needed</string>
     <string name="quick_filter_permission_usage_description">To filter by how recently apps were used, allow usage access in Settings. This lets the app see which apps are active and which have been sitting idle.</string>
@@ -75,7 +90,7 @@
     <string name="sort_permission_storage_title">Allow usage access</string>
     <string name="sort_permission_storage_description">Sorting by Total Size measures each app\'s full footprint — installer, stored data, and cache combined. Grant usage access in Settings to enable this sort option.</string>
     <string name="filter_permissions_section">Permissions</string>
-    <string name="filter_permissions_count">+%d more</string>
+    <string name="filter_permissions_count" tools:ignore="PluralsCandidate">+%d more</string>
     <string name="filter_permissions_more">More… </string>
     <string name="filter_permissions_title">Filter by Permission</string>
     <string name="filter_permissions_quick_filters">Quick filters</string>
@@ -83,7 +98,10 @@
     <string name="filter_permissions_chip_match_any">Match: Any</string>
     <string name="filter_permissions_chip_match_all">Match: All</string>
     <string name="filter_permissions_chip_presets">Presets</string>
-    <string name="filter_permissions_chip_presets_count">%d presets</string>
+    <plurals name="filter_permissions_chip_presets_count">
+        <item quantity="one">%d preset</item>
+        <item quantity="other">%d presets</item>
+    </plurals>
     <string name="filter_permissions_chip_show_all">Show: All</string>
     <string name="filter_permissions_chip_show_selected">Show: Selected</string>
     <string name="filter_permissions_presets_description">Tap a preset to select a group of related permissions at once.</string>


### PR DESCRIPTION
## Summary
- convert all quantity-dependent labels to Android plurals resources
- pluralize both quantities independently in app-detail count summaries
- use `pluralStringResource` at affected Compose call sites
- narrowly suppress one invariant “+%d more” label

## Validation
- affected feature modules compile and lint successfully
- `PluralsCandidate` findings: 0