### PR TITLE
Resolve UseKtx lint findings

### DIFF
--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppExportManagerImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppExportManagerImpl.kt
@@ -9,6 +9,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.provider.OpenableColumns
+import androidx.core.graphics.createBitmap
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -152,7 +153,7 @@ internal class AppExportManagerImpl @Inject constructor(
         }
         val width = intrinsicWidth.takeIf { it > 0 } ?: DEFAULT_ICON_SIZE
         val height = intrinsicHeight.takeIf { it > 0 } ?: DEFAULT_ICON_SIZE
-        return Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888).also { bitmap ->
+        return createBitmap(width, height).also { bitmap ->
             val previousBounds = android.graphics.Rect(bounds)
             setBounds(0, 0, width, height)
             draw(Canvas(bitmap))

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/util/AppOperations.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/util/AppOperations.kt
@@ -4,7 +4,6 @@ import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.provider.Settings
 import androidx.core.net.toUri
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
@@ -50,7 +49,7 @@ fun Context.sendForeignBroadcast(packageName: PackageName, receiverName: String)
 
 fun Context.openBrowser(url: String) {
     try {
-        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
     } catch (e: ActivityNotFoundException) {
         Logger.w(TAG, e, "No browser available to open $url")
     }

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/icons/app/PackageIconFetcher.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/icons/app/PackageIconFetcher.kt
@@ -1,7 +1,6 @@
 package sk.styk.martin.apkanalyzer.core.uilibrary.icons.app
 
 import android.content.pm.PackageManager
-import android.graphics.drawable.BitmapDrawable
 import androidx.core.graphics.drawable.toBitmap
 import coil3.ImageLoader
 import coil3.asImage
@@ -55,7 +54,7 @@ internal class PackageIconFetcher(private val data: AppReference, private val pa
 
         val bitmap = drawable.toBitmap()
         return ImageFetchResult(
-            image = BitmapDrawable(null, bitmap).asImage(),
+            image = bitmap.asImage(),
             isSampled = false,
             dataSource = DataSource.MEMORY,
         )


### PR DESCRIPTION
## Summary
- `AppOperations.kt`: `Uri.parse(url)` → `url.toUri()`, matching the two other `.toUri()` calls already in the file
- `AppExportManagerImpl.kt`: `Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)` → `createBitmap(width, height)` (KTX default is already `ARGB_8888`)
- `PackageIconFetcher.kt`: `BitmapDrawable(null, bitmap).asImage()` → `bitmap.asImage()`, dropping the unnecessary intermediate `Drawable` wrap (mirrors what Coil's own `Drawable.asImage()` does internally for a `BitmapDrawable`)

All three were flagged by Android Lint's `UseKtx` check (`./gradlew lintDebug`), which isn't part of the detekt pipeline. No new dependencies needed — `androidx.core:core-ktx` is already transitively on each module's compile classpath.

## Test plan
- [x] `./gradlew :core:common:compileDebugKotlin :core:apps:compileDebugKotlin :core:ui-library:compileDebugKotlin` — success
- [x] `./gradlew :core:common:lintDebug :core:apps:lintDebug :core:ui-library:lintDebug` — zero `UseKtx` findings remain
- [x] `./gradlew spotlessApply`