### PR TITLE
Cache AppDetail lookups for APK files

### DIFF
--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -61,7 +61,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
     dispatcherProvider: DispatcherProvider,
 ) : AppDetailRepository {
 
-    private val cache = ConcurrentHashMap<PackageName, AppDetail>()
+    private val cache = ConcurrentHashMap<CacheKey, AppDetail>()
 
     private val analysisFlags = PackageManager.GET_SIGNING_CERTIFICATES or
         PackageManager.GET_ACTIVITIES or
@@ -86,7 +86,8 @@ internal class AppDetailRepositoryImpl @Inject constructor(
     }
 
     private suspend fun installedPackageDetails(packageName: PackageName): Result<AppDetail> {
-        cache[packageName]?.let { return Result.success(it) }
+        val cacheKey = CacheKey.InstalledPackage(packageName)
+        cache[cacheKey]?.let { return Result.success(it) }
         Logger.d(TAG, "Loading details of $packageName")
         return runCatchingCancellable {
             val reference = AppReference.InstalledPackage(packageName)
@@ -100,19 +101,24 @@ internal class AppDetailRepositoryImpl @Inject constructor(
                 totalSize = storageStatsRepository.queryTotalSize(packageName),
                 lastUsedTime = usageStatsRepository.queryLastUsedTime(packageName),
             )
-        }.onSuccess { cache[packageName] = it }
+        }.onSuccess { cache[cacheKey] = it }
     }
 
-    private suspend fun apkFilePackageDetails(accessibleFile: File): Result<AppDetail> = runCatchingCancellable {
-        val reference = AppReference.ApkFile(accessibleFile.absolutePath)
-        val intentFilters = manifestParser.componentIntentFilters(reference)
-        getPackageDetails(
-            analysisMode = AppDetail.AnalysisMode.ApkFile,
-            packageInfo = packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
-                ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}"),
-            intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
-            areIntentFiltersAvailable = intentFilters.isSuccess,
-        )
+    private suspend fun apkFilePackageDetails(accessibleFile: File): Result<AppDetail> {
+        val cacheKey = CacheKey.ApkFile(accessibleFile.absolutePath, accessibleFile.lastModified())
+        cache[cacheKey]?.let { return Result.success(it) }
+        Logger.d(TAG, "Loading details of ${accessibleFile.absolutePath}")
+        return runCatchingCancellable {
+            val reference = AppReference.ApkFile(accessibleFile.absolutePath)
+            val intentFilters = manifestParser.componentIntentFilters(reference)
+            getPackageDetails(
+                analysisMode = AppDetail.AnalysisMode.ApkFile,
+                packageInfo = packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
+                    ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}"),
+                intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
+                areIntentFiltersAvailable = intentFilters.isSuccess,
+            )
+        }.onSuccess { cache[cacheKey] = it }
     }
 
     private fun getPackageDetails(
@@ -303,6 +309,11 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         packageInfo?.applicationInfo?.sourceDir = pathToPackage
         packageInfo?.applicationInfo?.publicSourceDir = pathToPackage
         return packageInfo
+    }
+
+    private sealed interface CacheKey {
+        data class InstalledPackage(val packageName: PackageName) : CacheKey
+        data class ApkFile(val path: String, val lastModified: Long) : CacheKey
     }
 
     companion object {

--- a/docs/product/features/app-detail.md
+++ b/docs/product/features/app-detail.md
@@ -3,10 +3,11 @@
 **Roadmap:** [FR-10 … FR-18](../roadmap.md#12-app-detail), [FR-25](../roadmap.md#15-export--share), plus [EX-07, EX-08](../roadmap.md#18-data-gaps--extraction-that-doesnt-exist-yet) · R0
 **Status:** Shipped. [All six implementation steps](#implementation-order) are built and wired,
 including Requirements and the polish pass. Two pieces described below are still open: the
-Requirements `Libraries` scope, blocked on roadmap data-extraction item `FR-44`; and exported-
-component risk interpretation on the hub, which now has all its data (`EX-07` and `EX-08` have both
-landed and back the Components screen's filter and item sheet) but still needs a deliberate hub rule
-rather than more extraction — see `RI-03`.
+Requirements `Libraries` scope, which needed roadmap data-extraction item `FR-44` — now backlogged
+as low-value, so the screen stays Hardware-only for the foreseeable future; and exported-component
+risk interpretation on the hub, which now has all its data (`EX-07` and `EX-08` have both landed and
+back the Components screen's filter and item sheet) but still needs a deliberate hub rule rather than
+more extraction — see `RI-03`.
 **Scope:** surface everything `AppDetail` holds inside `feature:app-detail`, provide a readable
 manifest, and finish base-APK and icon export.
 
@@ -479,8 +480,10 @@ supplies?"), and `org.apache.http.legacy` on a modern app says something the har
 will. Libraries carry the same required/optional split, from `android:required`, and the same
 device check — a declared library either resolves on this device or does not.
 
-The library list needs extraction that does not exist yet; it depends on roadmap `FR-44`. If that
-slips, the scope chip does not render and the screen is hardware-only, exactly as it is today.
+The library list needs extraction that does not exist yet — roadmap `FR-44`, now backlogged as
+low-value (most apps declare zero `<uses-library>` entries, and the ones that do are boilerplate or
+legacy trivia). Until that's revisited, the scope chip does not render and the screen stays
+hardware-only, exactly as it is today.
 
 ---
 
@@ -587,7 +590,7 @@ Screen work:
 - Certificate fingerprint group open with all three hashes; public key fingerprint group in an
   expander, collapsed by default, same three hashes and same treatment inside.
 
-### Step 4 — Requirements screen — Shipped, Libraries scope pending `FR-44`
+### Step 4 — Requirements screen — Shipped, Libraries scope backlogged (`FR-44`)
 
 - **Split `Feature` into a sealed interface** — `Hardware(name)` and `OpenGlEs(version)` — and stop
   writing `name = it.name ?: it.glEsVersion` in `AppDetailRepositoryImpl.getFeatures`. Keep the raw
@@ -609,10 +612,9 @@ Screen work:
 - Mark misses only, count them into the summary line, and soften the wording for optional misses.
   Runs in both analysis modes — see the [screen notes](#requirements-features) for why an installed
   app can still miss.
-- **Libraries scope**, only if `FR-44` has landed: reuse `SelectorChip` from Step 1, apply the
-  same required/optional split and the same device check to declared `<uses-library>` entries. If
-  `FR-44` has not landed, skip this bullet — the chip does not render and nothing else changes.
-  **Not yet built** — `FR-44` hasn't landed, so the screen remains Hardware-only.
+- **Libraries scope**, only if `FR-44` is picked back up: reuse `SelectorChip` from Step 1, apply
+  the same required/optional split and the same device check to declared `<uses-library>` entries.
+  **Not planned** — `FR-44` is backlogged as low-value, so the screen remains Hardware-only.
 
 ### Step 5 — Hub rework — Shipped
 
@@ -667,15 +669,12 @@ Screen work:
 
 ## Open questions
 
-- **Repeated loading on APK-file input only.** `AppDetailRepositoryImpl` is `@Singleton` and holds a
-  `ConcurrentHashMap<String, AppDetail>` keyed by package name, invalidated by
-  `PackageChangesObserver`. Installed packages are parsed once and every section ViewModel after
-  that is a map lookup — no problem there. But `details(AppReference.ApkFile(...))` has **no
-  cache**: each call runs `getPackageArchiveInfo` plus certificate extraction against the file
-  again. With five
-  section screens, opening an APK re-parses the archive on every navigation. Fix is small — key the
-  same cache by file path plus last-modified — but decide whether it belongs in this work or as a
-  separate `:core:apps` change.
+- ~~**Repeated loading on APK-file input only.**~~ **Fixed.** `AppDetailRepositoryImpl`'s cache key
+  is now a `CacheKey` sealed type — `InstalledPackage(packageName)` or
+  `ApkFile(path, lastModified)` — instead of a bare `PackageName`, so `details(AppReference.ApkFile(...))`
+  hits the same cache installed packages already used. `lastModified` in the key means a changed file
+  on disk naturally misses instead of serving a stale parse; the whole map is still cleared by
+  `PackageChangesObserver` on any package change, same as before.
 - **Permission descriptions on APK-file input.** `loadDescription()` resolves against the system
   package manager, so platform permissions work, but permissions declared by a not-installed app
   have no system description. The declaring-package fallback covers that case (see Step 1).

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -99,7 +99,7 @@ What Changed tab in R1.
 | FR-12 | Permissions view (per app)          | Done    | `feature:app-detail` → `permissions`; scope selector, filter chips, protection-level sections, item sheet |
 | FR-13 | Components views                    | Done    | One searchable/filterable screen for activities, services, receivers, and providers |
 | FR-14 | Certificate detail view             | Done    | Full signer, validity, signing status, serial, certificate fingerprints, and expandable public-key fingerprints |
-| FR-15 | Features (uses-feature) view        | Done    | `feature:app-detail` → `requirements`; required/optional split, per-device check, dedicated GL ES handling. `Libraries` scope still needs `FR-44` |
+| FR-15 | Features (uses-feature) view        | Done    | `feature:app-detail` → `requirements`; required/optional split, per-device check, dedicated GL ES handling. `Libraries` scope needs `FR-44`, now backlogged — screen stays Hardware-only |
 | FR-16 | Manifest viewer                     | Done    | Readable namespaced XML with line-based search for installed packages and APK files |
 | FR-17 | Exported components view            | Partial | Exported/Unprotected filter chips ship in the Components screen (`FR-13`), backed by both intent filters (`EX-07`) and content-provider path permissions (`EX-08`), both done. Still a technical filter, not a risk verdict — needs a deliberate hub rule (see `RI-03`) before exposure becomes a "Worth knowing" finding |
 | FR-18 | Custom permission audit             | Partial | Permissions screen's `Defined` scope lists the app's declared permissions with full detail sheets; no audit judgment (e.g. protection-level risk) applied yet |
@@ -160,9 +160,9 @@ doing in R0 rather than later.
 | FR-39 | App category                      | Done   | `InstalledApp.category` (`AppCategory` enum) from `ApplicationInfo.category`; feeds the `FR-43` browse dimension |
 | EX-07 | Component intent filters          | Done   | What an exported component actually responds to. Backs `ComponentIntentFilterKey` / `IntentFiltersScreen` in the Components screen (`FR-13`) and is available for `RI-03`. `EX-08` is the remaining half `FR-17` needs before exposure becomes a hub finding |
 | EX-08 | Content-provider path permissions | Done   | `<path-permission>` read/write grants per path, read straight off `ProviderInfo.pathPermissions` (already fetched via `GET_PROVIDERS`, no manifest parsing needed). Feeds the Components screen's `Unprotected` filter and item sheet; hub interpretation still needs a rule, tracked under `RI-03` |
-| FR-44 | Declared `<uses-library>` entries  | Todo   | Name and `android:required`, from the manifest for APK files and `sharedLibraryFiles` for installed apps. The platform-library half of device requirements — `org.apache.http.legacy` on a modern app is a signal the hardware list cannot give |
+| FR-44 | Declared `<uses-library>` entries  | Backlog | Name and `android:required`, from the manifest for APK files and `sharedLibraryFiles` for installed apps. Deprioritized: most apps declare zero entries, and the ones that do are boilerplate (`android.test.runner`) or legacy trivia (`org.apache.http.legacy`) — the value is screen completeness, not a real finding. Revisit if a concrete tracker/risk signal ends up needing it |
 
-**R0 scope:** CE-01, CE-05, FR-08 … FR-21, FR-24 … FR-44, EX-07, EX-08. Excludes the retired FR-22/FR-23 and the backlogged CE-06.
+**R0 scope:** CE-01, CE-05, FR-08 … FR-21, FR-24 … FR-43, EX-07, EX-08. Excludes the retired FR-22/FR-23 and the backlogged CE-06/FR-44.
 **R0 estimate: ~7–8 weeks** (was ~4, which assumed the ported items were already present).
 Retiring the statistics screen roughly pays for the browse screen — one surface instead of two,
 against an index that is already two-thirds built.
@@ -351,7 +351,7 @@ entry points were retired with the statistics screen — see §1.4.)*
 
 | ID | Release         | Contents                                                       | Duration     | Cumulative |
 |----|-----------------|-----------------------------------------------------------------|--------------|------------|
-| R0 | Free Rework     | CE-01, CE-05, FR-08 … FR-21, FR-24 … FR-44, EX-07, EX-08, plus `EN`    | ~7–8 weeks   | Week 8     |
+| R0 | Free Rework     | CE-01, CE-05, FR-08 … FR-21, FR-24 … FR-43, EX-07, EX-08, plus `EN`    | ~7–8 weeks   | Week 8     |
 | R1 | Pro Launch      | `HI`, `RI`, `TR`, `RP`, `CP`                                    | ~5.5–6.5 weeks | Week 15  |
 | R2 | Bulk Tools      | `BX`                                                            | ~1.5–2 weeks | Week 17    |
 | R3 | Optional polish | OP-01 … OP-03                                                   | as-needed    | Ongoing    |


### PR DESCRIPTION
## Summary
- `AppDetailRepositoryImpl` had no cache for `AppReference.ApkFile` lookups — only installed packages were cached, keyed by `PackageName`. Every navigation between the five app-detail section screens re-parsed the archive with `getPackageArchiveInfo` and re-ran certificate extraction.
- Replaced the bare `PackageName` cache key with a `CacheKey` sealed type (`InstalledPackage(packageName)` / `ApkFile(path, lastModified)`), so APK-file lookups now hit the same `ConcurrentHashMap` cache installed packages already used. `lastModified` in the key means a changed file on disk naturally misses the cache instead of serving a stale parse. `PackageChangesObserver` still clears the whole map on any package change, unchanged.
- This was a documented open question in `docs/product/features/app-detail.md` — updated that doc to mark it fixed.
- Also updated `docs/product/roadmap.md`: `FR-44` (declared `<uses-library>` entries) moved from `Todo` to `Backlog`. Most apps declare zero entries, and the ones that do are boilerplate (`android.test.runner`) or legacy trivia (`org.apache.http.legacy`) — the value is Requirements-screen completeness, not a real finding, so it's not worth building right now.

## Test plan
- [x] `./gradlew :core:apps:compileDebugKotlin` — success
- [x] `./gradlew spotlessApply`