### PR TITLE
Migrate Android resources DSL

### DIFF
--- a/.claude/skills/create-feature-module/SKILL.md
+++ b/.claude/skills/create-feature-module/SKILL.md
@@ -18,14 +18,13 @@ plugins {
 android {
     namespace = "sk.styk.martin.apkanalyzer.feature.<name>.api"
 
-    buildFeatures {
-        androidResources = false
-    }
+    androidResources.enable = false
 }
 ```
 
-Drop the `buildFeatures` block once this module gets its own `res/` — most commonly in Step 8, when
-a top-level destination needs its tab-label string in `feature/<name>/api/src/main/res/values/strings.xml`.
+Drop the `androidResources.enable` line once this module gets its own `res/` — most commonly in
+Step 8, when a top-level destination needs its tab-label string in
+`feature/<name>/api/src/main/res/values/strings.xml`.
 
 **`feature/<name>/api/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/<name>/api/<Name>NavKey.kt`**
 ```kotlin
@@ -55,9 +54,7 @@ plugins {
 android {
     namespace = "sk.styk.martin.apkanalyzer.feature.<name>.impl"
 
-    buildFeatures {
-        androidResources = false
-    }
+    androidResources.enable = false
 }
 
 dependencies {
@@ -69,7 +66,7 @@ dependencies {
 }
 ```
 
-Drop the `buildFeatures` block as soon as the screen has real UI copy and gets its own
+Drop the `androidResources.enable` line as soon as the screen has real UI copy and gets its own
 `res/values/strings.xml` — every user-facing string in this module's Composables must come from
 `stringResource`, so this almost always happens by the time Step 4's placeholder is replaced.
 
@@ -208,4 +205,3 @@ The root `AGENTS.md` does not list individual modules, so there is nothing to up
 | Package segment | concatenated lowercase | `feature.appdetail.impl` |
 | NavKey class | PascalCase + `NavKey` | `AppDetailNavKey` |
 | Entry provider function | camelCase + `Entries` | `appDetailEntries` |
-

--- a/core/apk-files/build.gradle.kts
+++ b/core/apk-files/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
 android {
     namespace = "sk.styk.martin.apkanalyzer.core.apkfiles"
 
-    buildFeatures {
-        androidResources = false
-    }
+    androidResources.enable = false
 }
 
 dependencies {

--- a/core/app-index/build.gradle.kts
+++ b/core/app-index/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
 android {
     namespace = "sk.styk.martin.apkanalyzer.core.appindex"
 
-    buildFeatures {
-        androidResources = false
-    }
+    androidResources.enable = false
 }
 
 dependencies {

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
 android {
     namespace = "sk.styk.martin.apkanalyzer.core.common"
 
-    buildFeatures {
-        androidResources = false
-    }
+    androidResources.enable = false
 }
 
 dependencies {

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -6,7 +6,5 @@ plugins {
 android {
     namespace = "sk.styk.martin.apkanalyzer.core.navigation"
 
-    buildFeatures {
-        androidResources = false
-    }
+    androidResources.enable = false
 }

--- a/core/user-preferences/build.gradle.kts
+++ b/core/user-preferences/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
 android {
     namespace = "sk.styk.martin.apkanalyzer.core.userpreferences"
 
-    buildFeatures {
-        androidResources = false
-    }
+    androidResources.enable = false
 }
 
 dependencies {

--- a/feature/app-detail/api/build.gradle.kts
+++ b/feature/app-detail/api/build.gradle.kts
@@ -5,7 +5,5 @@ plugins {
 android {
     namespace = "sk.styk.martin.apkanalyzer.feature.appdetail.api"
 
-    buildFeatures {
-        androidResources = false
-    }
+    androidResources.enable = false
 }

--- a/feature/settings/api/build.gradle.kts
+++ b/feature/settings/api/build.gradle.kts
@@ -5,7 +5,5 @@ plugins {
 android {
     namespace = "sk.styk.martin.apkanalyzer.feature.settings.api"
 
-    buildFeatures {
-        androidResources = false
-    }
+    androidResources.enable = false
 }


### PR DESCRIPTION
## Summary
- migrate seven modules from the deprecated `buildFeatures.androidResources` property to `androidResources.enable`
- update the feature-module generator skill to use the supported AGP API for new API and implementation modules
- preserve disabled Android resource processing while eliminating the AGP 10.0 deprecation warnings

## Validation
- `./gradlew help --warning-mode all`
- `./gradlew validateAgentContext`
- `./gradlew spotlessApply`