### PR TITLE
Upgrade artifact actions to Node 24 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/apk-analyzer.apk
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: apk-analyzer
           path: app/build/outputs/apk/debug/apk-analyzer.apk
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Download APK artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: apk-analyzer
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           mv "${{ steps.sign_apk.outputs.signedReleaseFile }}" "app/build/outputs/apk/release/apk-analyzer-${{ github.ref_name }}.apk"
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: apk-analyzer-aab
           path: app/build/outputs/bundle/release/apk-analyzer-${{ github.ref_name }}.aab
@@ -128,7 +128,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: apk-analyzer-apk
           path: app/build/outputs/apk/release/apk-analyzer-${{ github.ref_name }}.apk
@@ -136,7 +136,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload mapping file artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: apk-analyzer-mapping
           path: app/build/outputs/mapping/release/mapping.txt
@@ -154,7 +154,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download APK artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: apk-analyzer-apk
           path: artifacts
@@ -182,13 +182,13 @@ jobs:
 
     steps:
       - name: Download AAB artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: apk-analyzer-aab
           path: artifacts
 
       - name: Download mapping file artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: apk-analyzer-mapping
           path: artifacts
@@ -209,7 +209,7 @@ jobs:
 
     steps:
       - name: Download APK artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: apk-analyzer-apk
           path: artifacts


### PR DESCRIPTION
## Summary

- upgrade `actions/upload-artifact` from v4 to v7 in CI and release workflows
- upgrade `actions/download-artifact` from v4 to v8 in CI and release workflows
- preserve all artifact names, paths, retention, compression, and failure behavior

Both current action majors declare the supported Node.js 24 runtime, removing the Node.js 20 runtime warning and the `punycode`, `url.parse()`, and `Buffer()` deprecation warning group seen in the referenced CI run.

## References

- Warning source: https://github.com/MartinStyk/AndroidApkAnalyzer/actions/runs/31300503607
- `upload-artifact` current release: https://github.com/actions/upload-artifact/releases/tag/v7.0.1
- `upload-artifact@v7` runtime declaration: https://github.com/actions/upload-artifact/blob/v7/action.yml
- `download-artifact` current release: https://github.com/actions/download-artifact/releases/tag/v8.0.1
- `download-artifact@v8` runtime declaration: https://github.com/actions/download-artifact/blob/v8/action.yml

## Validation

- confirmed every artifact action occurrence in `.github/workflows/ci.yml` and `.github/workflows/release.yml` uses the current major
- confirmed the workflow diff contains only action version changes
- ran `./gradlew spotlessApply`