### PR TITLE
Enable native access for the Gradle launcher

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 ##############################################################################
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
+DEFAULT_JVM_OPTS="--enable-native-access=ALL-UNNAMED"
 
 APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -9,7 +9,7 @@
 if "%OS%"=="Windows_NT" setlocal
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
+set DEFAULT_JVM_OPTS=--enable-native-access=ALL-UNNAMED
 
 set DIRNAME=%~dp0
 if "%DIRNAME%" == "" set DIRNAME=.


### PR DESCRIPTION
## Summary
- enable native access in both Gradle wrapper launcher scripts
- cover every wrapper invocation in CI, agent-context validation, and release workflows without duplicating workflow environment settings

## Why
JDK 25 reports the restricted `System.load` call from Gradle's `native-platform` library in the Gradle launcher process. `org.gradle.jvmargs` configures the daemon and would not reliably reach that warning-producing launcher. Setting `--enable-native-access=ALL-UNNAMED` in `DEFAULT_JVM_OPTS` passes it directly to the JVM that starts `GradleWrapperMain`, before Gradle loads the native library.

## Validation
- reproduced the warning locally with an unmodified wrapper on JDK 25
- confirmed both Windows and Unix wrappers launch on JDK 25 without the warning after the change
- ran a real `gradlew help --no-daemon` invocation on JDK 25 without the warning
- ran `spotlessApply`