### PR TITLE
Include split APKs in app size and show split count (FR-34)

### DIFF
--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -175,7 +175,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             source = installSourceResolver.getAppInstallSource(packageInfo),
             appInstaller = installSourceResolver.appInstallingPackage(packageInfo),
             installLocation = InstallLocation.from(packageInfo.installLocation),
-            apkSize = computeApkSize(applicationInfo?.sourceDir),
+            apkSize = computeApkSize(applicationInfo),
             firstInstallTime = if (packageInfo.firstInstallTime > 0) Instant.ofEpochMilli(packageInfo.firstInstallTime) else null,
             lastUpdateTime = if (packageInfo.lastUpdateTime > 0) Instant.ofEpochMilli(packageInfo.lastUpdateTime) else null,
             minSdkVersion = minSdk,
@@ -184,6 +184,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             targetSdkLabel = sdkVersionResolver.resolveVersion(applicationInfo?.targetSdkVersion),
             totalSize = totalSize,
             lastUsedTime = lastUsedTime,
+            additionalInstalledSplits = applicationInfo?.splitSourceDirs.orEmpty().size,
         )
     }
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/AnalysisUtils.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/AnalysisUtils.kt
@@ -13,7 +13,11 @@ import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import java.io.File
 
-fun computeApkSize(sourceDir: String?): AppSize = (sourceDir?.let { File(it).length() } ?: 0L).bytes
+fun computeApkSize(applicationInfo: ApplicationInfo?): AppSize {
+    val baseApkSize = applicationInfo?.sourceDir?.let { File(it).length() } ?: 0L
+    val splitApksSize = applicationInfo?.splitSourceDirs.orEmpty().sumOf { File(it).length() }
+    return (baseApkSize + splitApksSize).bytes
+}
 
 @Suppress("DEPRECATION")
 internal fun resolveProtectionLevel(protection: Int): ProtectionLevel = when (protection) {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/AppInfo.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/AppInfo.kt
@@ -33,4 +33,5 @@ data class AppInfo(
     val targetSdkLabel: String? = null,
     val totalSize: AppSize? = null,
     val lastUsedTime: Instant? = null,
+    val additionalInstalledSplits: Int = 0,
 )

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -82,14 +82,13 @@ doing in R0 rather than later.
 | ID    | Item                              | Status  | Why it matters                                                                                       |
 |-------|-----------------------------------|---------|---------------------------------------------------------------------------------------------------------|
 | FR-33 | Native libraries / ABIs           | Todo    | Was in the Pro backlog; it's raw data, so free. Also the cheapest tracker-detection signal (`TR-03`) |
-| FR-34 | Split APKs / config splits        | Todo    | Most modern installs are splits; APK size and "what's installed" are both wrong without it           |
 | FR-36 | Signing scheme version & signers  | Todo    | v1–v4, multi-signer, rotation history — feeds `CE-02` / `CE-03`                                       |
 | FR-37 | Storage breakdown                 | Todo    | `StorageStats` already gives app/data/cache; only the total is used                                  |
 | FR-38 | Full install-source chain         | Todo    | Only `installingPackageName` is read; initiating + originating package are what actually distinguish a sideload from a store install |
 | FR-44 | Declared `<uses-library>` entries | Backlog | Name and `android:required`, from the manifest for APK files and `sharedLibraryFiles` for installed apps. Deprioritized: most apps declare zero entries, and the ones that do are boilerplate (`android.test.runner`) or legacy trivia (`org.apache.http.legacy`) — the value is screen completeness, not a real finding. Revisit if a concrete tracker/risk signal ends up needing it |
 
 **R0 remaining:** FR-17, FR-18 (Partial — blocked on `RI-03`, a Pro/R1 item), CE-06 (Backlog),
-FR-26, FR-27, FR-31 (blocked on `OQ-01`), FR-33, FR-34, FR-36 … FR-38, FR-44 (Backlog), plus `EN`.
+FR-26, FR-27, FR-31 (blocked on `OQ-01`), FR-33, FR-36 … FR-38, FR-44 (Backlog), plus `EN`.
 Everything else originally scoped for R0 has shipped — see [shipped.md](shipped.md).
 
 ---
@@ -265,7 +264,7 @@ interpretation (that's `RP`) but *tedium removed*: nobody opens 300 app reports 
 
 | ID | Release         | Contents                                                                              | Duration       | Cumulative |
 |----|-----------------|-----------------------------------------------------------------------------------------|----------------|------------|
-| R0 | Free Rework     | Remaining: FR-17, FR-18, CE-06, FR-26, FR-27, FR-31, FR-33 … FR-38, FR-44, plus `EN` — rest shipped, see [shipped.md](shipped.md) | ~7–8 weeks     | Week 8     |
+| R0 | Free Rework     | Remaining: FR-17, FR-18, CE-06, FR-26, FR-27, FR-31, FR-33, FR-36 … FR-38, FR-44, plus `EN` — rest shipped, see [shipped.md](shipped.md) | ~7–8 weeks     | Week 8     |
 | R1 | Pro Launch      | `HI`, `RI`, `TR`, `RP`, `CP`                                                             | ~5.5–6.5 weeks | Week 15    |
 | R2 | Bulk Tools      | `BX`                                                                                     | ~1.5–2 weeks   | Week 17    |
 | R3 | Optional polish | OP-01 … OP-03                                                                            | as-needed      | Ongoing    |

--- a/docs/product/shipped.md
+++ b/docs/product/shipped.md
@@ -53,5 +53,5 @@ FR-28 Theme / color scheme setting · FR-29 Settings screen · FR-30 Usage-acces
 
 ## 1.8 Data Gaps
 
-FR-32 Manifest security flags · FR-35 Shared UID group · FR-39 App category ·
-EX-07 Component intent filters · EX-08 Content-provider path permissions
+FR-32 Manifest security flags · FR-34 Split APKs / config splits · FR-35 Shared UID group ·
+FR-39 App category · EX-07 Component intent filters · EX-08 Content-provider path permissions

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -312,6 +313,19 @@ private fun LoadedContent(
                 onShowRationale = { rationaleRow = it },
                 onCopy = onCopy,
             )
+            if (state.additionalInstalledSplits > 0) {
+                InfoRowItem(
+                    label = stringResource(R.string.general_info_split_apks),
+                    value = pluralStringResource(
+                        R.plurals.general_info_split_apks_value,
+                        state.additionalInstalledSplits,
+                        state.additionalInstalledSplits,
+                    ),
+                    rationale = stringResource(R.string.general_info_rationale_split_apks),
+                    onShowRationale = { rationaleRow = it },
+                    onCopy = onCopy,
+                )
+            }
             state.totalSize?.let { size ->
                 InfoRowItem(
                     label = stringResource(R.string.general_info_total_size),
@@ -473,6 +487,7 @@ private fun sampleGeneralInfoState() = GeneralInfoState.Loaded(
     installLocation = "Internal",
     apkSize = 152.megabytes,
     totalSize = 510.megabytes,
+    additionalInstalledSplits = 3,
 )
 
 @Composable

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoState.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoState.kt
@@ -38,6 +38,7 @@ sealed interface GeneralInfoState {
         val installLocation: String,
         val apkSize: AppSize,
         val totalSize: AppSize?,
+        val additionalInstalledSplits: Int,
     ) : GeneralInfoState
 
     data object Error : GeneralInfoState

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoViewModel.kt
@@ -98,4 +98,5 @@ private fun AppDetail.toGeneralInfoState() = GeneralInfoState.Loaded(
     installLocation = info.installLocation.name,
     apkSize = info.apkSize,
     totalSize = info.totalSize,
+    additionalInstalledSplits = info.additionalInstalledSplits,
 )

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -236,6 +236,11 @@
     <string name="general_info_data_directory">Data Directory</string>
     <string name="general_info_install_location">Install Location</string>
     <string name="general_info_apk_size">APK Size</string>
+    <string name="general_info_split_apks">Split APKs</string>
+    <plurals name="general_info_split_apks_value">
+        <item quantity="one">Installed as %1$d split APK</item>
+        <item quantity="other">Installed as %1$d split APKs</item>
+    </plurals>
     <string name="general_info_total_size">Total Size</string>
 
     <!-- General Info: Rationale Descriptions -->
@@ -264,7 +269,8 @@
     <string name="general_info_rationale_apk_directory">The file system path where the APK file is stored on the device.</string>
     <string name="general_info_rationale_data_directory">The file system path where the app stores its private data, databases, and shared preferences.</string>
     <string name="general_info_rationale_install_location">The preferred storage location declared by the developer — internal storage, external storage, or automatic.</string>
-    <string name="general_info_rationale_apk_size">The size of the APK file on disk, excluding app data, caches, and runtime-generated files.</string>
+    <string name="general_info_rationale_apk_size">The combined size of the installed APK files on disk, excluding app data, caches, and runtime-generated files. Most apps installed from Google Play are split into a base APK plus additional APKs for your device\'s language and screen density; this total covers all of them.</string>
+    <string name="general_info_rationale_split_apks">This app was installed as a base APK plus additional split APKs, a delivery format Google Play uses to send only the code and resources your device needs. The APK size above already adds them all together.</string>
     <string name="general_info_rationale_total_size">The combined size of the APK, app data, and cached files. Requires usage access permission.</string>
 
     <string name="permissions_title">Permissions</string>


### PR DESCRIPTION
## Summary
- `computeApkSize` previously measured only `base.apk` via `applicationInfo.sourceDir`, silently ignoring every split/config APK — `AppInfo.apkSize` understated real installed size for the many apps Play installs as splits.
- `computeApkSize` now takes the full `ApplicationInfo` and sums the base APK plus every file in `splitSourceDirs`. APK-file analysis is unaffected: `splitSourceDirs` is never populated when parsing a standalone `.apk` archive.
- Added `AppInfo.additionalInstalledSplits` (mirrors `ManifestParser`'s existing `additionalInstalledSplits` naming/semantics), populated from the same `splitSourceDirs` array already used by `AppExportManagerImpl` and `ManifestParserImpl`.
- General Info screen shows a new "Split APKs" row (tap = explain, long-press = copy, same `InfoRowItem`/`RationaleBottomSheet` idiom as every other row) only when the app actually has splits.
- Updated the APK size rationale copy since it now reflects the true combined installed size rather than just the base file, and added a rationale explaining what split APKs are.
- Roadmap bookkeeping: removed FR-34 from `docs/product/roadmap.md` (Data Gaps table, "R0 remaining" list, Release Plan R0 row) and added it to `docs/product/shipped.md` §1.8.

## Test plan
- [x] `./gradlew :core:apps:compileDebugKotlin :feature:app-detail:impl:compileDebugKotlin` — succeeds
- [x] `./gradlew spotlessApply` — no formatting changes needed beyond what was already written
- [ ] Manual: open General Info for a Play-installed app with splits and confirm the new row appears and APK size includes split sizes