### PR TITLE
Add native libraries / ABIs to General Information (FR-33)

### DIFF
--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -28,6 +28,8 @@ analysis/
   InstallSourceResolver.kt / Impl   - Determine app install source (Play Store, sideload, etc.)
   SdkVersionResolver.kt             - SDK version to Android name mapping
   AnalysisUtils.kt                   - Shared analysis helpers, incl. permission protection decoding
+                                        and `readNativeLibraries()`, which opens the APK's `sourceDir`
+                                        as a zip and reads `lib/<abi>/*.so` entries directly
 model/
   InstalledApp.kt         - Basic installed app info (packageName, name, sizes, times, source,
                             targetSdk, minSdk, sharedUserId, category)
@@ -63,6 +65,9 @@ model/
   DeviceFeatures.kt       - The device side of that comparison: available feature names plus the
                             device's GL ES version. `supports()` returns `null` for unknown, never
                             `false` — an unreadable package manager must not read as "missing"
+  NativeLibraries.kt      - ABI folders and distinct `.so` filenames an APK actually ships, read from
+                            its zip entries rather than trusted from `primaryCpuAbi`/`secondaryCpuAbi`,
+                            which describe what the device picked, not what the APK contains
   InstallLocation.kt      - Install location enum
 di/                       - Hilt module bindings
 ```
@@ -109,6 +114,11 @@ them apart: `AppDetailRepositoryImpl` caches `AppDetail` keyed by package and in
 `PackageChangesObserver`, so folding device state into it would make cached entries depend on a
 second input the key does not mention and the invalidation does not track. Consumers inject both
 repositories and combine them while mapping to state.
+
+`NativeLibraries` follows the same split: it holds only what the APK ships (ABIs, `.so` filenames).
+`Build.SUPPORTED_ABIS` is read where it's consumed (see `GeneralInfoViewModel`), not folded into the
+cached model — it's a plain static field, not an expensive call, so it doesn't warrant a repository
+the way `DeviceFeaturesRepository` does for `getSystemAvailableFeatures()`.
 
 ## Component Intent Filters
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -17,6 +17,7 @@ import sk.styk.martin.apkanalyzer.core.apps.analysis.InstallSourceResolver
 import sk.styk.martin.apkanalyzer.core.apps.analysis.ManifestParser
 import sk.styk.martin.apkanalyzer.core.apps.analysis.SdkVersionResolver
 import sk.styk.martin.apkanalyzer.core.apps.analysis.computeApkSize
+import sk.styk.martin.apkanalyzer.core.apps.analysis.readNativeLibraries
 import sk.styk.martin.apkanalyzer.core.apps.analysis.resolvePathPermissions
 import sk.styk.martin.apkanalyzer.core.apps.analysis.resolveProtectionFlags
 import sk.styk.martin.apkanalyzer.core.apps.analysis.resolveProtectionLevel
@@ -146,6 +147,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         receivers = getBroadcastReceivers(packageInfo, intentFiltersByComponent),
         permissions = getPermissions(packageInfo),
         features = getFeatures(packageInfo),
+        nativeLibraries = readNativeLibraries(packageInfo.applicationInfo?.sourceDir),
         areComponentIntentFiltersAvailable = areIntentFiltersAvailable,
     )
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/AnalysisUtils.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/analysis/AnalysisUtils.kt
@@ -5,15 +5,42 @@ import android.content.pm.PathPermission
 import android.content.pm.PermissionInfo
 import android.os.PatternMatcher
 import sk.styk.martin.apkanalyzer.core.apps.model.AppCategory
+import sk.styk.martin.apkanalyzer.core.apps.model.NativeLibraries
 import sk.styk.martin.apkanalyzer.core.apps.model.ProtectionFlag
 import sk.styk.martin.apkanalyzer.core.apps.model.ProtectionLevel
 import sk.styk.martin.apkanalyzer.core.apps.model.ProviderPathMatchType
 import sk.styk.martin.apkanalyzer.core.apps.model.ProviderPathPermission
+import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import java.io.File
+import java.util.zip.ZipFile
+
+private const val TAG = "AnalysisUtils"
+
+private val nativeLibraryEntryRegex = Regex("""^lib/([^/]+)/([^/]+\.so)$""")
 
 fun computeApkSize(sourceDir: String?): AppSize = (sourceDir?.let { File(it).length() } ?: 0L).bytes
+
+fun readNativeLibraries(sourceDir: String?): NativeLibraries {
+    if (sourceDir == null) return NativeLibraries.Empty
+    return runCatching {
+        ZipFile(sourceDir).use { zip ->
+            val abis = mutableSetOf<String>()
+            val libraryNames = mutableSetOf<String>()
+            zip.entries().asSequence()
+                .mapNotNull { nativeLibraryEntryRegex.matchEntire(it.name) }
+                .forEach { match ->
+                    abis += match.groupValues[1]
+                    libraryNames += match.groupValues[2]
+                }
+            NativeLibraries(abis = abis.sorted(), libraryNames = libraryNames.sorted())
+        }
+    }.getOrElse {
+        Logger.w(TAG, it, "Can not read native libraries from $sourceDir")
+        NativeLibraries.Empty
+    }
+}
 
 @Suppress("DEPRECATION")
 internal fun resolveProtectionLevel(protection: Int): ProtectionLevel = when (protection) {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/AppDetail.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/AppDetail.kt
@@ -10,6 +10,7 @@ data class AppDetail(
     val receivers: List<BroadcastReceiver>,
     val permissions: Permissions,
     val features: List<Feature>,
+    val nativeLibraries: NativeLibraries,
     val areComponentIntentFiltersAvailable: Boolean,
 ) {
     enum class AnalysisMode {

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/NativeLibraries.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/NativeLibraries.kt
@@ -1,0 +1,10 @@
+package sk.styk.martin.apkanalyzer.core.apps.model
+
+data class NativeLibraries(val abis: List<String>, val libraryNames: List<String>) {
+    val hasNativeCode: Boolean
+        get() = abis.isNotEmpty()
+
+    companion object {
+        val Empty = NativeLibraries(abis = emptyList(), libraryNames = emptyList())
+    }
+}

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -81,7 +81,6 @@ doing in R0 rather than later.
 
 | ID    | Item                              | Status  | Why it matters                                                                                       |
 |-------|-----------------------------------|---------|---------------------------------------------------------------------------------------------------------|
-| FR-33 | Native libraries / ABIs           | Todo    | Was in the Pro backlog; it's raw data, so free. Also the cheapest tracker-detection signal (`TR-03`) |
 | FR-34 | Split APKs / config splits        | Todo    | Most modern installs are splits; APK size and "what's installed" are both wrong without it           |
 | FR-36 | Signing scheme version & signers  | Todo    | v1–v4, multi-signer, rotation history — feeds `CE-02` / `CE-03`                                       |
 | FR-37 | Storage breakdown                 | Todo    | `StorageStats` already gives app/data/cache; only the total is used                                  |
@@ -89,7 +88,7 @@ doing in R0 rather than later.
 | FR-44 | Declared `<uses-library>` entries | Backlog | Name and `android:required`, from the manifest for APK files and `sharedLibraryFiles` for installed apps. Deprioritized: most apps declare zero entries, and the ones that do are boilerplate (`android.test.runner`) or legacy trivia (`org.apache.http.legacy`) — the value is screen completeness, not a real finding. Revisit if a concrete tracker/risk signal ends up needing it |
 
 **R0 remaining:** FR-17, FR-18 (Partial — blocked on `RI-03`, a Pro/R1 item), CE-06 (Backlog),
-FR-26, FR-27, FR-31 (blocked on `OQ-01`), FR-33, FR-34, FR-36 … FR-38, FR-44 (Backlog), plus `EN`.
+FR-26, FR-27, FR-31 (blocked on `OQ-01`), FR-34, FR-36 … FR-38, FR-44 (Backlog), plus `EN`.
 Everything else originally scoped for R0 has shipped — see [shipped.md](shipped.md).
 
 ---
@@ -265,7 +264,7 @@ interpretation (that's `RP`) but *tedium removed*: nobody opens 300 app reports 
 
 | ID | Release         | Contents                                                                              | Duration       | Cumulative |
 |----|-----------------|-----------------------------------------------------------------------------------------|----------------|------------|
-| R0 | Free Rework     | Remaining: FR-17, FR-18, CE-06, FR-26, FR-27, FR-31, FR-33 … FR-38, FR-44, plus `EN` — rest shipped, see [shipped.md](shipped.md) | ~7–8 weeks     | Week 8     |
+| R0 | Free Rework     | Remaining: FR-17, FR-18, CE-06, FR-26, FR-27, FR-31, FR-34 … FR-38, FR-44, plus `EN` — rest shipped, see [shipped.md](shipped.md) | ~7–8 weeks     | Week 8     |
 | R1 | Pro Launch      | `HI`, `RI`, `TR`, `RP`, `CP`                                                             | ~5.5–6.5 weeks | Week 15    |
 | R2 | Bulk Tools      | `BX`                                                                                     | ~1.5–2 weeks   | Week 17    |
 | R3 | Optional polish | OP-01 … OP-03                                                                            | as-needed      | Ongoing    |

--- a/docs/product/shipped.md
+++ b/docs/product/shipped.md
@@ -53,5 +53,5 @@ FR-28 Theme / color scheme setting · FR-29 Settings screen · FR-30 Usage-acces
 
 ## 1.8 Data Gaps
 
-FR-32 Manifest security flags · FR-35 Shared UID group · FR-39 App category ·
-EX-07 Component intent filters · EX-08 Content-provider path permissions
+FR-32 Manifest security flags · FR-33 Native libraries / ABIs · FR-35 Shared UID group ·
+FR-39 App category · EX-07 Component intent filters · EX-08 Content-provider path permissions

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/components/InfoRowItem.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/components/InfoRowItem.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
@@ -69,7 +71,9 @@ internal fun RationaleBottomSheet(
 ) {
     BottomSheet(onDismiss = onDismiss, modifier = modifier) {
         Column(
-            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 16.dp),
         ) {
             Text(
                 text = row.label,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoScreen.kt
@@ -20,11 +20,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.persistentListOf
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.megabytes
@@ -323,6 +325,12 @@ private fun LoadedContent(
             }
         }
 
+        NativeLibrariesSection(
+            state = state,
+            onShowRationale = { rationaleRow = it },
+            onCopy = onCopy,
+        )
+
         Spacer(modifier = Modifier.height(4.dp))
     }
 
@@ -405,6 +413,72 @@ private fun SecuritySettingsSection(
     }
 }
 
+@Composable
+private fun NativeLibrariesSection(
+    state: GeneralInfoState.Loaded,
+    onShowRationale: (InfoRow) -> Unit,
+    onCopy: (label: String, value: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SectionCard(
+        title = stringResource(R.string.general_info_section_native_libraries),
+        modifier = modifier,
+    ) {
+        val abisValue = if (state.nativeLibraryAbis.isNotEmpty()) {
+            state.nativeLibraryAbis.joinToString()
+        } else {
+            stringResource(R.string.general_info_native_library_abis_none)
+        }
+        val abisRationale = buildString {
+            append(stringResource(R.string.general_info_rationale_native_library_abis))
+            append(' ')
+            append(
+                stringResource(
+                    R.string.general_info_native_library_device_support,
+                    state.deviceSupportedAbis.joinToString(),
+                ),
+            )
+            if (state.isNativeLibraryDeviceIncompatible) {
+                append(' ')
+                append(stringResource(R.string.general_info_native_library_incompatible))
+            }
+        }
+        InfoRowItem(
+            label = stringResource(R.string.general_info_native_library_abis),
+            value = abisValue,
+            rationale = abisRationale,
+            onShowRationale = onShowRationale,
+            onCopy = onCopy,
+        )
+
+        val fileCount = state.nativeLibraryNames.size
+        val filesValue = if (fileCount > 0) {
+            pluralStringResource(R.plurals.general_info_native_library_file_count, fileCount, fileCount)
+        } else {
+            stringResource(R.string.general_info_native_library_files_none)
+        }
+        val filesRationale = buildString {
+            append(stringResource(R.string.general_info_rationale_native_library_files))
+            if (fileCount > 0) {
+                append(' ')
+                append(
+                    stringResource(
+                        R.string.general_info_native_library_file_list,
+                        state.nativeLibraryNames.joinToString(),
+                    ),
+                )
+            }
+        }
+        InfoRowItem(
+            label = stringResource(R.string.general_info_native_library_files),
+            value = filesValue,
+            rationale = filesRationale,
+            onShowRationale = onShowRationale,
+            onCopy = onCopy,
+        )
+    }
+}
+
 private fun formatTimestamp(instant: Instant): String {
     val dateFormat = SimpleDateFormat("dd MMM yyyy, HH:mm", Locale.getDefault())
     return dateFormat.format(Date.from(instant))
@@ -473,6 +547,10 @@ private fun sampleGeneralInfoState() = GeneralInfoState.Loaded(
     installLocation = "Internal",
     apkSize = 152.megabytes,
     totalSize = 510.megabytes,
+    nativeLibraryAbis = persistentListOf("arm64-v8a", "armeabi-v7a"),
+    nativeLibraryNames = persistentListOf("libapp.so", "libcrashlytics.so", "libcrypto.so"),
+    deviceSupportedAbis = persistentListOf("arm64-v8a", "armeabi-v7a"),
+    isNativeLibraryDeviceIncompatible = false,
 )
 
 @Composable

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoState.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoState.kt
@@ -1,6 +1,7 @@
 package sk.styk.martin.apkanalyzer.feature.appdetail.impl.generalinfo
 
 import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
@@ -38,6 +39,10 @@ sealed interface GeneralInfoState {
         val installLocation: String,
         val apkSize: AppSize,
         val totalSize: AppSize?,
+        val nativeLibraryAbis: ImmutableList<String>,
+        val nativeLibraryNames: ImmutableList<String>,
+        val deviceSupportedAbis: ImmutableList<String>,
+        val isNativeLibraryDeviceIncompatible: Boolean,
     ) : GeneralInfoState
 
     data object Error : GeneralInfoState

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoViewModel.kt
@@ -1,11 +1,13 @@
 package sk.styk.martin.apkanalyzer.feature.appdetail.impl.generalinfo
 
+import android.os.Build
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -98,4 +100,9 @@ private fun AppDetail.toGeneralInfoState() = GeneralInfoState.Loaded(
     installLocation = info.installLocation.name,
     apkSize = info.apkSize,
     totalSize = info.totalSize,
+    nativeLibraryAbis = nativeLibraries.abis.toImmutableList(),
+    nativeLibraryNames = nativeLibraries.libraryNames.toImmutableList(),
+    deviceSupportedAbis = Build.SUPPORTED_ABIS.toList().toImmutableList(),
+    isNativeLibraryDeviceIncompatible = nativeLibraries.hasNativeCode &&
+        nativeLibraries.abis.none { it in Build.SUPPORTED_ABIS },
 )

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -203,6 +203,7 @@
     <string name="general_info_section_security">Security settings</string>
     <string name="general_info_section_installation">Installation &amp; Source</string>
     <string name="general_info_section_storage">Storage &amp; Paths</string>
+    <string name="general_info_section_native_libraries">Native libraries</string>
 
     <!-- General Info: Row Labels -->
     <string name="general_info_application_name">Application Name</string>
@@ -237,6 +238,14 @@
     <string name="general_info_install_location">Install Location</string>
     <string name="general_info_apk_size">APK Size</string>
     <string name="general_info_total_size">Total Size</string>
+    <string name="general_info_native_library_abis">CPU architectures</string>
+    <string name="general_info_native_library_abis_none">No native code</string>
+    <string name="general_info_native_library_files">Native library files</string>
+    <string name="general_info_native_library_files_none">None bundled</string>
+    <plurals name="general_info_native_library_file_count">
+        <item quantity="one">%1$d file</item>
+        <item quantity="other">%1$d files</item>
+    </plurals>
 
     <!-- General Info: Rationale Descriptions -->
     <string name="general_info_rationale_application_name">The user-visible label of the app, as shown on the home screen and in the app drawer.</string>
@@ -266,6 +275,11 @@
     <string name="general_info_rationale_install_location">The preferred storage location declared by the developer — internal storage, external storage, or automatic.</string>
     <string name="general_info_rationale_apk_size">The size of the APK file on disk, excluding app data, caches, and runtime-generated files.</string>
     <string name="general_info_rationale_total_size">The combined size of the APK, app data, and cached files. Requires usage access permission.</string>
+    <string name="general_info_rationale_native_library_abis">The processor types this app includes compiled native code for, read from the APK\'s own files rather than what this device reports.</string>
+    <string name="general_info_native_library_device_support">This device supports: %1$s.</string>
+    <string name="general_info_native_library_incompatible">None of those processor types match what this device supports, so this app\'s native code likely won\'t run here.</string>
+    <string name="general_info_rationale_native_library_files">The distinct native code files bundled in the app, counted once even when repeated across multiple processor architectures.</string>
+    <string name="general_info_native_library_file_list">Bundled files: %1$s.</string>
 
     <string name="permissions_title">Permissions</string>
     <string name="permissions_error">Could not read the permissions of this app.</string>


### PR DESCRIPTION
## Summary
- Adds `NativeLibraries` (`core/apps/.../model/NativeLibraries.kt`): the set of ABI folders an APK ships (`lib/<abi>/`) and the distinct `.so` filenames bundled, read directly from the APK's zip entries rather than trusted from `primaryCpuAbi`/`secondaryCpuAbi` — those describe what the device picked, not what the APK contains.
- Extracts it in `AppDetailRepositoryImpl.getPackageDetails` via a new `readNativeLibraries()` helper in `AnalysisUtils.kt`, used uniformly for both installed packages and APK files since both already resolve to a `sourceDir`.
- Adds a new "Native libraries" section to the General Information screen with two rows (`tap = explain, long-press = copy`, matching the existing `InfoRowItem`/`RationaleBottomSheet` idiom): CPU architectures shipped, and the count of bundled native library files. The ABI row's explanation also states which ABIs this device supports and flags when none of the APK's ABIs match — a simple compatibility signal without a full requirements-style check.
- Device ABI comparison (`Build.SUPPORTED_ABIS`) is computed in `GeneralInfoViewModel`, not folded into the cached `AppDetail` — same separation the module already applies to `Feature`/`DeviceFeatures`, documented in `core/apps/AGENTS.md`.
- Makes `RationaleBottomSheet`'s content scrollable so a long bundled-library list doesn't clip on smaller screens.
- This is raw data extraction only (roadmap `FR-33`), free-tier; it's also flagged as the cheapest future signal for tracker-library matching (`TR-03`), not implemented here.
- Roadmap bookkeeping: removes the `FR-33` row from `docs/product/roadmap.md` §1.8 and its two "remaining" list references, and adds it to `docs/product/shipped.md` §1.8.

## Test plan
- [x] `./gradlew :core:apps:compileDebugKotlin :feature:app-detail:impl:compileDebugKotlin` — builds clean
- [x] `./gradlew spotlessApply` — no formatting diffs beyond the authored changes
- [x] `./gradlew :feature:app-detail:impl:parseDebugLocalResources --rerun` — new `strings.xml`/`plurals` entries parse correctly
- [ ] Not verified on-device; General Info section renders through existing `SectionCard`/`InfoRowItem` components with a preview added for sample data

🤖 Generated with [Claude Code](https://claude.com/claude-code)