### PR TITLE
Add copy/share app summary to app detail hub (FR-26)

### DIFF
--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/resources/ResourcesManager.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/resources/ResourcesManager.kt
@@ -5,7 +5,6 @@ import androidx.annotation.ArrayRes
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.Dimension
-import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
@@ -16,9 +15,6 @@ class ResourcesManager
 @Inject
 constructor(@ApplicationContext val context: Context) {
     fun getString(@StringRes stringRes: Int, vararg args: Any): CharSequence = context.getString(stringRes, *args)
-
-    fun getQuantityString(@PluralsRes pluralsRes: Int, quantity: Int, vararg args: Any): CharSequence =
-        context.resources.getQuantityString(pluralsRes, quantity, *args)
 
     fun getStringArray(@ArrayRes stringArrayRes: Int): Array<String> = context.resources.getStringArray(stringArrayRes)
 

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/resources/ResourcesManager.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/resources/ResourcesManager.kt
@@ -5,6 +5,7 @@ import androidx.annotation.ArrayRes
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.Dimension
+import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
@@ -15,6 +16,9 @@ class ResourcesManager
 @Inject
 constructor(@ApplicationContext val context: Context) {
     fun getString(@StringRes stringRes: Int, vararg args: Any): CharSequence = context.getString(stringRes, *args)
+
+    fun getQuantityString(@PluralsRes pluralsRes: Int, quantity: Int, vararg args: Any): CharSequence =
+        context.resources.getQuantityString(pluralsRes, quantity, *args)
 
     fun getStringArray(@ArrayRes stringArrayRes: Int): Array<String> = context.resources.getStringArray(stringArrayRes)
 

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/icons/ApkAnalyzerIcons.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/icons/ApkAnalyzerIcons.kt
@@ -55,6 +55,7 @@ import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.Sensors
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.SettingsInputAntenna
+import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material.icons.rounded.Smartphone
 import androidx.compose.material.icons.rounded.Sms
 import androidx.compose.material.icons.rounded.Storage
@@ -133,6 +134,7 @@ data object ApkAnalyzerIcons {
     val Lock = Icons.Rounded.Lock
     val Search = Icons.Rounded.Search
     val Settings = Icons.Rounded.Settings
+    val Share = Icons.Rounded.Share
     val Sort = Icons.Rounded.SwapVert
     val Sync = Icons.Rounded.Sync
     val FileUpload = Icons.Rounded.UploadFile

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -64,7 +64,6 @@ section has shipped except:
 
 | ID    | Item                        | Status | Notes                                                    |
 |-------|-----------------------------|--------|-----------------------------------------------------------|
-| FR-26 | Copy / share app summary    | Todo   | `ClipboardManager` already in `core:common`              |
 | FR-27 | Launch a component          | Todo   | `startForeignActivity` exists and is unused               |
 
 ### 1.7 Invisible Infrastructure
@@ -89,7 +88,7 @@ doing in R0 rather than later.
 | FR-44 | Declared `<uses-library>` entries | Backlog | Name and `android:required`, from the manifest for APK files and `sharedLibraryFiles` for installed apps. Deprioritized: most apps declare zero entries, and the ones that do are boilerplate (`android.test.runner`) or legacy trivia (`org.apache.http.legacy`) — the value is screen completeness, not a real finding. Revisit if a concrete tracker/risk signal ends up needing it |
 
 **R0 remaining:** FR-17, FR-18 (Partial — blocked on `RI-03`, a Pro/R1 item), CE-06 (Backlog),
-FR-26, FR-27, FR-31 (blocked on `OQ-01`), FR-33, FR-34, FR-36 … FR-38, FR-44 (Backlog), plus `EN`.
+FR-27, FR-31 (blocked on `OQ-01`), FR-33, FR-34, FR-36 … FR-38, FR-44 (Backlog), plus `EN`.
 Everything else originally scoped for R0 has shipped — see [shipped.md](shipped.md).
 
 ---
@@ -265,7 +264,7 @@ interpretation (that's `RP`) but *tedium removed*: nobody opens 300 app reports 
 
 | ID | Release         | Contents                                                                              | Duration       | Cumulative |
 |----|-----------------|-----------------------------------------------------------------------------------------|----------------|------------|
-| R0 | Free Rework     | Remaining: FR-17, FR-18, CE-06, FR-26, FR-27, FR-31, FR-33 … FR-38, FR-44, plus `EN` — rest shipped, see [shipped.md](shipped.md) | ~7–8 weeks     | Week 8     |
+| R0 | Free Rework     | Remaining: FR-17, FR-18, CE-06, FR-27, FR-31, FR-33 … FR-38, FR-44, plus `EN` — rest shipped, see [shipped.md](shipped.md) | ~7–8 weeks     | Week 8     |
 | R1 | Pro Launch      | `HI`, `RI`, `TR`, `RP`, `CP`                                                             | ~5.5–6.5 weeks | Week 15    |
 | R2 | Bulk Tools      | `BX`                                                                                     | ~1.5–2 weeks   | Week 17    |
 | R3 | Optional polish | OP-01 … OP-03                                                                            | as-needed      | Ongoing    |

--- a/docs/product/shipped.md
+++ b/docs/product/shipped.md
@@ -45,7 +45,7 @@ natively once statistics and browse stopped being separate screens.
 
 ## 1.5 Export & Share
 
-FR-24 APK export / share · FR-25 Icon export
+FR-24 APK export / share · FR-25 Icon export · FR-26 Copy / share app summary
 
 ## 1.6 App & UI
 

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailAction.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailAction.kt
@@ -7,6 +7,7 @@ internal sealed interface AppDetailAction {
     data object ViewManifest : AppDetailAction
     data object ExportApk : AppDetailAction
     data object SaveIcon : AppDetailAction
+    data object ViewSummary : AppDetailAction
     data object CopySummary : AppDetailAction
     data object ShareSummary : AppDetailAction
     data object ShareSummaryUnavailable : AppDetailAction

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailAction.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailAction.kt
@@ -7,6 +7,9 @@ internal sealed interface AppDetailAction {
     data object ViewManifest : AppDetailAction
     data object ExportApk : AppDetailAction
     data object SaveIcon : AppDetailAction
+    data object CopySummary : AppDetailAction
+    data object ShareSummary : AppDetailAction
+    data object ShareSummaryUnavailable : AppDetailAction
     data object OpenPlayStore : AppDetailAction
     data object OpenAppInfo : AppDetailAction
     data object NavigateGeneralDetails : AppDetailAction

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailEvent.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailEvent.kt
@@ -6,6 +6,7 @@ internal sealed interface AppDetailEvent {
     data class OpenPlayStore(val packageName: PackageName) : AppDetailEvent
     data class OpenAppInfo(val packageName: PackageName) : AppDetailEvent
     data class CreateDocument(val export: AppDetailExport, val suggestedName: String) : AppDetailEvent
+    data class ShareSummary(val text: String) : AppDetailEvent
     data class ShowFeedback(val feedback: AppDetailFeedback) : AppDetailEvent
     data object NavigateToManifest : AppDetailEvent
     data object NavigateToGeneralDetails : AppDetailEvent
@@ -25,4 +26,6 @@ internal sealed interface AppDetailFeedback {
     data object ApkSaveFailed : AppDetailFeedback
     data object IconSaveFailed : AppDetailFeedback
     data object DocumentPickerUnavailable : AppDetailFeedback
+    data object SummaryCopied : AppDetailFeedback
+    data object ShareUnavailable : AppDetailFeedback
 }

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailEvent.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailEvent.kt
@@ -6,6 +6,7 @@ internal sealed interface AppDetailEvent {
     data class OpenPlayStore(val packageName: PackageName) : AppDetailEvent
     data class OpenAppInfo(val packageName: PackageName) : AppDetailEvent
     data class CreateDocument(val export: AppDetailExport, val suggestedName: String) : AppDetailEvent
+    data class ShowSummaryPreview(val text: String) : AppDetailEvent
     data class ShareSummary(val text: String) : AppDetailEvent
     data class ShowFeedback(val feedback: AppDetailFeedback) : AppDetailEvent
     data object NavigateToManifest : AppDetailEvent

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailFormatting.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailFormatting.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.annotation.PluralsRes
 import sk.styk.martin.apkanalyzer.core.apps.model.CertificateTrustLevel
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
-import sk.styk.martin.apkanalyzer.core.common.resources.ResourcesManager
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.util.Date
@@ -25,89 +24,89 @@ internal fun formatTimestamp(instant: Instant): String {
     return dateFormat.format(Date.from(instant))
 }
 
-internal fun AppDetailState.Loaded.toSummaryText(resourcesManager: ResourcesManager): String = buildList {
-    add(resourcesManager.getString(R.string.app_detail_summary_header, appName, packageName.value).toString())
-    add(summaryLine(resourcesManager, R.string.app_detail_version, versionSummary(resourcesManager)))
-    minSdkSummary(resourcesManager)?.let { add(summaryLine(resourcesManager, R.string.general_info_min_sdk, it)) }
-    targetSdkSummary(resourcesManager)?.let { add(summaryLine(resourcesManager, R.string.general_info_target_sdk, it)) }
-    add(summaryLine(resourcesManager, R.string.general_info_install_source, sourceSummary(resourcesManager)))
-    add(summaryLine(resourcesManager, R.string.app_detail_apk_size, apkSize.formatted()))
-    totalSize?.let { add(summaryLine(resourcesManager, R.string.app_detail_total_size, it.formatted())) }
-    signingSummary(resourcesManager)?.let { add(summaryLine(resourcesManager, R.string.app_detail_summary_signing_label, it)) }
-    add(summaryLine(resourcesManager, R.string.app_detail_permissions_section, permissionsSummary(resourcesManager)))
+internal fun AppDetailState.Loaded.toSummaryText(context: Context): String = buildList {
+    add(context.getString(R.string.app_detail_summary_header, appName, packageName.value))
+    add(summaryLine(context, R.string.app_detail_version, versionSummary(context)))
+    minSdkSummary(context)?.let { add(summaryLine(context, R.string.general_info_min_sdk, it)) }
+    targetSdkSummary(context)?.let { add(summaryLine(context, R.string.general_info_target_sdk, it)) }
+    add(summaryLine(context, R.string.general_info_install_source, sourceSummary(context)))
+    add(summaryLine(context, R.string.app_detail_apk_size, apkSize.formatted()))
+    totalSize?.let { add(summaryLine(context, R.string.app_detail_total_size, it.formatted())) }
+    signingSummary(context)?.let { add(summaryLine(context, R.string.app_detail_summary_signing_label, it)) }
+    add(summaryLine(context, R.string.app_detail_permissions_section, permissionsSummary(context)))
 }.joinToString("\n")
 
 private fun summaryLine(
-    resourcesManager: ResourcesManager,
+    context: Context,
     labelRes: Int,
     value: String,
-): String = resourcesManager.getString(R.string.app_detail_summary_line, resourcesManager.getString(labelRes), value).toString()
+): String = context.getString(R.string.app_detail_summary_line, context.getString(labelRes), value)
 
-private fun AppDetailState.Loaded.versionSummary(resourcesManager: ResourcesManager): String =
-    versionName?.let { resourcesManager.getString(R.string.app_detail_summary_version, it, versionCode).toString() }
+private fun AppDetailState.Loaded.versionSummary(context: Context): String =
+    versionName?.let { context.getString(R.string.app_detail_summary_version, it, versionCode) }
         ?: versionCode.toString()
 
-private fun AppDetailState.Loaded.minSdkSummary(resourcesManager: ResourcesManager): String? = when {
+private fun AppDetailState.Loaded.minSdkSummary(context: Context): String? = when {
     minSdkLabel != null -> minSdkLabel
-    minSdkVersion != null -> resourcesManager.getString(R.string.app_detail_sdk_version_no_label, minSdkVersion).toString()
+    minSdkVersion != null -> context.getString(R.string.app_detail_sdk_version_no_label, minSdkVersion)
     else -> null
 }
 
-private fun AppDetailState.Loaded.targetSdkSummary(resourcesManager: ResourcesManager): String? = when {
+private fun AppDetailState.Loaded.targetSdkSummary(context: Context): String? = when {
     targetSdkLabel != null -> targetSdkLabel
-    targetSdkVersion != null -> resourcesManager.getString(R.string.app_detail_sdk_version_no_label, targetSdkVersion).toString()
+    targetSdkVersion != null -> context.getString(R.string.app_detail_sdk_version_no_label, targetSdkVersion)
     else -> null
 }
 
-private fun AppDetailState.Loaded.sourceSummary(resourcesManager: ResourcesManager): String = when (AppSource.valueOf(source)) {
-    AppSource.GooglePlay -> resourcesManager.getString(R.string.general_info_install_source_google_play)
-    AppSource.SystemPreinstalled -> resourcesManager.getString(R.string.general_info_install_source_system)
-    AppSource.Unknown -> resourcesManager.getString(R.string.general_info_install_source_unknown)
-}.toString()
+private fun AppDetailState.Loaded.sourceSummary(context: Context): String = when (AppSource.valueOf(source)) {
+    AppSource.GooglePlay -> context.getString(R.string.general_info_install_source_google_play)
+    AppSource.SystemPreinstalled -> context.getString(R.string.general_info_install_source_system)
+    AppSource.Unknown -> context.getString(R.string.general_info_install_source_unknown)
+}
 
-private fun AppDetailState.Loaded.signingSummary(resourcesManager: ResourcesManager): String? {
+private fun AppDetailState.Loaded.signingSummary(context: Context): String? {
     val cert = certificate ?: return null
     return when (cert.trustLevel) {
-        CertificateTrustLevel.Debug -> resourcesManager.getString(R.string.app_detail_certificate_debug).toString()
-        CertificateTrustLevel.Valid -> cert.signerDisplayName ?: resourcesManager.getString(R.string.certificates_self_signed).toString()
+        CertificateTrustLevel.Debug -> context.getString(R.string.app_detail_certificate_debug)
+        CertificateTrustLevel.Valid -> cert.signerDisplayName ?: context.getString(R.string.certificates_self_signed)
     }
 }
 
-private fun AppDetailState.Loaded.permissionsSummary(resourcesManager: ResourcesManager): String = grantedDangerousPermissionsCount?.let { granted ->
-    resourcesManager.getString(
+private fun AppDetailState.Loaded.permissionsSummary(context: Context): String = grantedDangerousPermissionsCount?.let { granted ->
+    context.getString(
         R.string.app_detail_summary_permissions_granted,
         permissionCountSummary(
-            resourcesManager = resourcesManager,
+            context = context,
             count = totalPermissionsCount,
             pluralsRes = R.plurals.app_detail_summary_permissions_requested,
         ),
         permissionCountSummary(
-            resourcesManager = resourcesManager,
+            context = context,
             count = dangerousPermissionsCount,
             pluralsRes = R.plurals.app_detail_summary_permissions_dangerous,
         ),
         permissionCountSummary(
-            resourcesManager = resourcesManager,
+            context = context,
             count = granted,
             pluralsRes = R.plurals.app_detail_summary_permissions_granted_count,
         ),
-    ).toString()
-} ?: resourcesManager.getString(
+    )
+} ?: context.getString(
     R.string.app_detail_summary_permissions,
     permissionCountSummary(
-        resourcesManager = resourcesManager,
+        context = context,
         count = totalPermissionsCount,
         pluralsRes = R.plurals.app_detail_summary_permissions_requested,
     ),
     permissionCountSummary(
-        resourcesManager = resourcesManager,
+        context = context,
         count = dangerousPermissionsCount,
         pluralsRes = R.plurals.app_detail_summary_permissions_dangerous,
     ),
-).toString()
+)
 
 private fun permissionCountSummary(
-    resourcesManager: ResourcesManager,
+    context: Context,
     count: Int,
     @PluralsRes pluralsRes: Int,
-): String = resourcesManager.getQuantityString(pluralsRes, count, count).toString()
+): String = context.resources.getQuantityString(pluralsRes, count, count)

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailFormatting.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailFormatting.kt
@@ -1,9 +1,6 @@
 package sk.styk.martin.apkanalyzer.feature.appdetail.impl
 
 import android.content.Context
-import androidx.annotation.PluralsRes
-import sk.styk.martin.apkanalyzer.core.apps.model.CertificateTrustLevel
-import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.util.Date
@@ -23,90 +20,3 @@ internal fun formatTimestamp(instant: Instant): String {
     val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
     return dateFormat.format(Date.from(instant))
 }
-
-internal fun AppDetailState.Loaded.toSummaryText(context: Context): String = buildList {
-    add(context.getString(R.string.app_detail_summary_header, appName, packageName.value))
-    add(summaryLine(context, R.string.app_detail_version, versionSummary(context)))
-    minSdkSummary(context)?.let { add(summaryLine(context, R.string.general_info_min_sdk, it)) }
-    targetSdkSummary(context)?.let { add(summaryLine(context, R.string.general_info_target_sdk, it)) }
-    add(summaryLine(context, R.string.general_info_install_source, sourceSummary(context)))
-    add(summaryLine(context, R.string.app_detail_apk_size, apkSize.formatted()))
-    totalSize?.let { add(summaryLine(context, R.string.app_detail_total_size, it.formatted())) }
-    signingSummary(context)?.let { add(summaryLine(context, R.string.app_detail_summary_signing_label, it)) }
-    add(summaryLine(context, R.string.app_detail_permissions_section, permissionsSummary(context)))
-}.joinToString("\n")
-
-private fun summaryLine(
-    context: Context,
-    labelRes: Int,
-    value: String,
-): String = context.getString(R.string.app_detail_summary_line, context.getString(labelRes), value)
-
-private fun AppDetailState.Loaded.versionSummary(context: Context): String =
-    versionName?.let { context.getString(R.string.app_detail_summary_version, it, versionCode) }
-        ?: versionCode.toString()
-
-private fun AppDetailState.Loaded.minSdkSummary(context: Context): String? = when {
-    minSdkLabel != null -> minSdkLabel
-    minSdkVersion != null -> context.getString(R.string.app_detail_sdk_version_no_label, minSdkVersion)
-    else -> null
-}
-
-private fun AppDetailState.Loaded.targetSdkSummary(context: Context): String? = when {
-    targetSdkLabel != null -> targetSdkLabel
-    targetSdkVersion != null -> context.getString(R.string.app_detail_sdk_version_no_label, targetSdkVersion)
-    else -> null
-}
-
-private fun AppDetailState.Loaded.sourceSummary(context: Context): String = when (AppSource.valueOf(source)) {
-    AppSource.GooglePlay -> context.getString(R.string.general_info_install_source_google_play)
-    AppSource.SystemPreinstalled -> context.getString(R.string.general_info_install_source_system)
-    AppSource.Unknown -> context.getString(R.string.general_info_install_source_unknown)
-}
-
-private fun AppDetailState.Loaded.signingSummary(context: Context): String? {
-    val cert = certificate ?: return null
-    return when (cert.trustLevel) {
-        CertificateTrustLevel.Debug -> context.getString(R.string.app_detail_certificate_debug)
-        CertificateTrustLevel.Valid -> cert.signerDisplayName ?: context.getString(R.string.certificates_self_signed)
-    }
-}
-
-private fun AppDetailState.Loaded.permissionsSummary(context: Context): String = grantedDangerousPermissionsCount?.let { granted ->
-    context.getString(
-        R.string.app_detail_summary_permissions_granted,
-        permissionCountSummary(
-            context = context,
-            count = totalPermissionsCount,
-            pluralsRes = R.plurals.app_detail_summary_permissions_requested,
-        ),
-        permissionCountSummary(
-            context = context,
-            count = dangerousPermissionsCount,
-            pluralsRes = R.plurals.app_detail_summary_permissions_dangerous,
-        ),
-        permissionCountSummary(
-            context = context,
-            count = granted,
-            pluralsRes = R.plurals.app_detail_summary_permissions_granted_count,
-        ),
-    )
-} ?: context.getString(
-    R.string.app_detail_summary_permissions,
-    permissionCountSummary(
-        context = context,
-        count = totalPermissionsCount,
-        pluralsRes = R.plurals.app_detail_summary_permissions_requested,
-    ),
-    permissionCountSummary(
-        context = context,
-        count = dangerousPermissionsCount,
-        pluralsRes = R.plurals.app_detail_summary_permissions_dangerous,
-    ),
-)
-
-private fun permissionCountSummary(
-    context: Context,
-    count: Int,
-    @PluralsRes pluralsRes: Int,
-): String = context.resources.getQuantityString(pluralsRes, count, count)

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailFormatting.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailFormatting.kt
@@ -1,6 +1,9 @@
 package sk.styk.martin.apkanalyzer.feature.appdetail.impl
 
 import android.content.Context
+import sk.styk.martin.apkanalyzer.core.apps.model.CertificateTrustLevel
+import sk.styk.martin.apkanalyzer.core.common.model.AppSource
+import sk.styk.martin.apkanalyzer.core.common.resources.ResourcesManager
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.util.Date
@@ -12,9 +15,72 @@ internal fun AppDetailFeedback.message(context: Context): String = when (this) {
     AppDetailFeedback.ApkSaveFailed -> context.getString(R.string.app_detail_apk_save_failed)
     AppDetailFeedback.IconSaveFailed -> context.getString(R.string.app_detail_icon_save_failed)
     AppDetailFeedback.DocumentPickerUnavailable -> context.getString(R.string.app_detail_document_picker_unavailable)
+    AppDetailFeedback.SummaryCopied -> context.getString(R.string.app_detail_summary_copied)
+    AppDetailFeedback.ShareUnavailable -> context.getString(R.string.app_detail_share_unavailable)
 }
 
 internal fun formatTimestamp(instant: Instant): String {
     val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
     return dateFormat.format(Date.from(instant))
 }
+
+internal fun AppDetailState.Loaded.toSummaryText(resourcesManager: ResourcesManager): String = buildList {
+    add(resourcesManager.getString(R.string.app_detail_summary_header, appName, packageName.value).toString())
+    add(summaryLine(resourcesManager, R.string.app_detail_version, versionSummary(resourcesManager)))
+    minSdkSummary(resourcesManager)?.let { add(summaryLine(resourcesManager, R.string.general_info_min_sdk, it)) }
+    targetSdkSummary(resourcesManager)?.let { add(summaryLine(resourcesManager, R.string.general_info_target_sdk, it)) }
+    add(summaryLine(resourcesManager, R.string.general_info_install_source, sourceSummary(resourcesManager)))
+    add(summaryLine(resourcesManager, R.string.app_detail_apk_size, apkSize.formatted()))
+    totalSize?.let { add(summaryLine(resourcesManager, R.string.app_detail_total_size, it.formatted())) }
+    signingSummary(resourcesManager)?.let { add(summaryLine(resourcesManager, R.string.app_detail_summary_signing_label, it)) }
+    add(summaryLine(resourcesManager, R.string.app_detail_permissions_section, permissionsSummary(resourcesManager)))
+}.joinToString("\n")
+
+private fun summaryLine(
+    resourcesManager: ResourcesManager,
+    labelRes: Int,
+    value: String,
+): String = resourcesManager.getString(R.string.app_detail_summary_line, resourcesManager.getString(labelRes), value).toString()
+
+private fun AppDetailState.Loaded.versionSummary(resourcesManager: ResourcesManager): String =
+    versionName?.let { resourcesManager.getString(R.string.app_detail_summary_version, it, versionCode).toString() }
+        ?: versionCode.toString()
+
+private fun AppDetailState.Loaded.minSdkSummary(resourcesManager: ResourcesManager): String? = when {
+    minSdkLabel != null -> minSdkLabel
+    minSdkVersion != null -> resourcesManager.getString(R.string.app_detail_sdk_version_no_label, minSdkVersion).toString()
+    else -> null
+}
+
+private fun AppDetailState.Loaded.targetSdkSummary(resourcesManager: ResourcesManager): String? = when {
+    targetSdkLabel != null -> targetSdkLabel
+    targetSdkVersion != null -> resourcesManager.getString(R.string.app_detail_sdk_version_no_label, targetSdkVersion).toString()
+    else -> null
+}
+
+private fun AppDetailState.Loaded.sourceSummary(resourcesManager: ResourcesManager): String = when (AppSource.valueOf(source)) {
+    AppSource.GooglePlay -> resourcesManager.getString(R.string.general_info_install_source_google_play)
+    AppSource.SystemPreinstalled -> resourcesManager.getString(R.string.general_info_install_source_system)
+    AppSource.Unknown -> resourcesManager.getString(R.string.general_info_install_source_unknown)
+}.toString()
+
+private fun AppDetailState.Loaded.signingSummary(resourcesManager: ResourcesManager): String? {
+    val cert = certificate ?: return null
+    return when (cert.trustLevel) {
+        CertificateTrustLevel.Debug -> resourcesManager.getString(R.string.app_detail_certificate_debug).toString()
+        CertificateTrustLevel.Valid -> cert.signerDisplayName ?: resourcesManager.getString(R.string.certificates_self_signed).toString()
+    }
+}
+
+private fun AppDetailState.Loaded.permissionsSummary(resourcesManager: ResourcesManager): String = grantedDangerousPermissionsCount?.let { granted ->
+    resourcesManager.getString(
+        R.string.app_detail_summary_permissions_granted,
+        totalPermissionsCount,
+        dangerousPermissionsCount,
+        granted,
+    ).toString()
+} ?: resourcesManager.getString(
+    R.string.app_detail_summary_permissions,
+    totalPermissionsCount,
+    dangerousPermissionsCount,
+).toString()

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailFormatting.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailFormatting.kt
@@ -1,6 +1,7 @@
 package sk.styk.martin.apkanalyzer.feature.appdetail.impl
 
 import android.content.Context
+import androidx.annotation.PluralsRes
 import sk.styk.martin.apkanalyzer.core.apps.model.CertificateTrustLevel
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.resources.ResourcesManager
@@ -75,12 +76,38 @@ private fun AppDetailState.Loaded.signingSummary(resourcesManager: ResourcesMana
 private fun AppDetailState.Loaded.permissionsSummary(resourcesManager: ResourcesManager): String = grantedDangerousPermissionsCount?.let { granted ->
     resourcesManager.getString(
         R.string.app_detail_summary_permissions_granted,
-        totalPermissionsCount,
-        dangerousPermissionsCount,
-        granted,
+        permissionCountSummary(
+            resourcesManager = resourcesManager,
+            count = totalPermissionsCount,
+            pluralsRes = R.plurals.app_detail_summary_permissions_requested,
+        ),
+        permissionCountSummary(
+            resourcesManager = resourcesManager,
+            count = dangerousPermissionsCount,
+            pluralsRes = R.plurals.app_detail_summary_permissions_dangerous,
+        ),
+        permissionCountSummary(
+            resourcesManager = resourcesManager,
+            count = granted,
+            pluralsRes = R.plurals.app_detail_summary_permissions_granted_count,
+        ),
     ).toString()
 } ?: resourcesManager.getString(
     R.string.app_detail_summary_permissions,
-    totalPermissionsCount,
-    dangerousPermissionsCount,
+    permissionCountSummary(
+        resourcesManager = resourcesManager,
+        count = totalPermissionsCount,
+        pluralsRes = R.plurals.app_detail_summary_permissions_requested,
+    ),
+    permissionCountSummary(
+        resourcesManager = resourcesManager,
+        count = dangerousPermissionsCount,
+        pluralsRes = R.plurals.app_detail_summary_permissions_dangerous,
+    ),
 ).toString()
+
+private fun permissionCountSummary(
+    resourcesManager: ResourcesManager,
+    count: Int,
+    @PluralsRes pluralsRes: Int,
+): String = resourcesManager.getQuantityString(pluralsRes, count, count).toString()

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
@@ -47,6 +47,7 @@ import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
 import sk.styk.martin.apkanalyzer.core.apps.model.CertificatePrincipal
 import sk.styk.martin.apkanalyzer.core.apps.model.CertificateTrustLevel
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
+import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.megabytes
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.Icon
@@ -63,6 +64,7 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.Shapes
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.AppDetailToolbar
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.AppSummaryBottomSheet
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.SplitApkExportBottomSheet
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.permissions.permissionIcon
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.requirements.requirementIcon
@@ -96,6 +98,7 @@ internal fun AppDetailScreen(
     val context = LocalContext.current
     val appReference = appDetailInput.toAppReference()
     var splitApkExportName by rememberSaveable { mutableStateOf<String?>(null) }
+    var summaryPreview by rememberSaveable { mutableStateOf<String?>(null) }
     val apkDocumentLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument(APK_MIME_TYPE),
     ) { destination ->
@@ -132,6 +135,8 @@ internal fun AppDetailScreen(
                         viewModel.onAction(AppDetailAction.DocumentPickerUnavailable(event.export))
                     }
                 }
+
+                is AppDetailEvent.ShowSummaryPreview -> summaryPreview = event.text
 
                 is AppDetailEvent.ShareSummary -> {
                     try {
@@ -188,6 +193,20 @@ internal fun AppDetailScreen(
         SplitApkExportBottomSheet(
             displayName = displayName,
             onDismiss = { splitApkExportName = null },
+        )
+    }
+    summaryPreview?.let { summary ->
+        AppSummaryBottomSheet(
+            summary = summary,
+            onCopy = {
+                viewModel.onAction(AppDetailAction.CopySummary)
+                summaryPreview = null
+            },
+            onShare = {
+                viewModel.onAction(AppDetailAction.ShareSummary)
+                summaryPreview = null
+            },
+            onDismiss = { summaryPreview = null },
         )
     }
 }
@@ -575,14 +594,9 @@ private fun ActionsSection(
                 enabled = state.exportInProgress == null,
             )
             ActionItem(
-                icon = ApkAnalyzerIcons.Copy,
-                label = stringResource(R.string.app_detail_action_copy_summary),
-                onClick = { onAction(AppDetailAction.CopySummary) },
-            )
-            ActionItem(
                 icon = ApkAnalyzerIcons.Share,
-                label = stringResource(R.string.app_detail_action_share_summary),
-                onClick = { onAction(AppDetailAction.ShareSummary) },
+                label = stringResource(R.string.app_detail_action_summary),
+                onClick = { onAction(AppDetailAction.ViewSummary) },
             )
             ActionItem(
                 icon = ApkAnalyzerIcons.Apps,
@@ -1064,7 +1078,7 @@ private fun AppDetailLoadedPreview() {
         uid = 10234,
         description = null,
         isSystemApp = false,
-        source = "GooglePlay",
+        source = AppSource.GooglePlay,
         apkDirectory = "/example/app/com.spotify.music/base.apk",
         dataDirectory = "/example/user/0/com.spotify.music",
         apkSize = 152.megabytes,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
@@ -73,6 +73,7 @@ import java.time.Instant
 private const val APK_MIME_TYPE = "application/vnd.android.package-archive"
 private const val ICON_MIME_TYPE = "image/png"
 
+@Suppress("CyclomaticComplexMethod")
 @Composable
 internal fun AppDetailScreen(
     appDetailInput: AppDetailInput,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailScreen.kt
@@ -1,6 +1,7 @@
 package sk.styk.martin.apkanalyzer.feature.appdetail.impl
 
 import android.content.ActivityNotFoundException
+import android.content.Intent
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -129,6 +130,18 @@ internal fun AppDetailScreen(
                         }
                     } catch (_: ActivityNotFoundException) {
                         viewModel.onAction(AppDetailAction.DocumentPickerUnavailable(event.export))
+                    }
+                }
+
+                is AppDetailEvent.ShareSummary -> {
+                    try {
+                        val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(Intent.EXTRA_TEXT, event.text)
+                        }
+                        context.startActivity(Intent.createChooser(shareIntent, null))
+                    } catch (_: ActivityNotFoundException) {
+                        viewModel.onAction(AppDetailAction.ShareSummaryUnavailable)
                     }
                 }
 
@@ -560,6 +573,16 @@ private fun ActionsSection(
                 },
                 onClick = { onAction(AppDetailAction.SaveIcon) },
                 enabled = state.exportInProgress == null,
+            )
+            ActionItem(
+                icon = ApkAnalyzerIcons.Copy,
+                label = stringResource(R.string.app_detail_action_copy_summary),
+                onClick = { onAction(AppDetailAction.CopySummary) },
+            )
+            ActionItem(
+                icon = ApkAnalyzerIcons.Share,
+                label = stringResource(R.string.app_detail_action_share_summary),
+                onClick = { onAction(AppDetailAction.ShareSummary) },
             )
             ActionItem(
                 icon = ApkAnalyzerIcons.Apps,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailState.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailState.kt
@@ -7,6 +7,7 @@ import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
 import sk.styk.martin.apkanalyzer.core.apps.model.CertificatePrincipal
 import sk.styk.martin.apkanalyzer.core.apps.model.CertificateTrustLevel
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
+import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.AppDetailBadge
 import java.time.Instant
@@ -31,7 +32,7 @@ internal sealed interface AppDetailState {
         val uid: Int?,
         val description: String?,
         val isSystemApp: Boolean,
-        val source: String,
+        val source: AppSource,
         val apkDirectory: String?,
         val dataDirectory: String?,
         val apkSize: AppSize,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
@@ -30,10 +30,13 @@ import sk.styk.martin.apkanalyzer.core.apps.model.DeviceFeatures
 import sk.styk.martin.apkanalyzer.core.apps.model.Feature
 import sk.styk.martin.apkanalyzer.core.apps.model.FeatureAvailability
 import sk.styk.martin.apkanalyzer.core.apps.model.ProtectionLevel
+import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
+import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
+import sk.styk.martin.apkanalyzer.core.common.resources.ResourcesManager
 import sk.styk.martin.apkanalyzer.core.userpreferences.RecentlyViewedAppsRepository
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.ApkFileLifetime
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
@@ -54,6 +57,8 @@ internal class AppDetailViewModel @AssistedInject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val temporaryApkManager: TemporaryApkManager,
     private val recentlyViewedAppsRepository: RecentlyViewedAppsRepository,
+    private val clipboardManager: ClipboardManager,
+    private val resourcesManager: ResourcesManager,
 ) : ViewModel() {
 
     @AssistedFactory
@@ -93,6 +98,12 @@ internal class AppDetailViewModel @AssistedInject constructor(
             is AppDetailAction.ExportApk -> requestDocument(AppDetailExport.Apk)
 
             is AppDetailAction.SaveIcon -> requestDocument(AppDetailExport.Icon)
+
+            is AppDetailAction.CopySummary -> copySummary()
+
+            is AppDetailAction.ShareSummary -> shareSummary()
+
+            is AppDetailAction.ShareSummaryUnavailable -> sendEvent(AppDetailEvent.ShowFeedback(AppDetailFeedback.ShareUnavailable))
 
             is AppDetailAction.OpenPlayStore -> withLoadedState { sendEvent(AppDetailEvent.OpenPlayStore(it.packageName)) }
 
@@ -151,6 +162,22 @@ internal class AppDetailViewModel @AssistedInject constructor(
             val extension = if (export == AppDetailExport.Apk) "apk" else "png"
             exportInProgress.value = export
             sendEvent(AppDetailEvent.CreateDocument(export, "${state.packageName}.$extension"))
+        }
+    }
+
+    private fun copySummary() {
+        withLoadedState { state ->
+            val summary = state.toSummaryText(resourcesManager)
+            val label = resourcesManager.getString(R.string.app_detail_summary_clip_label, state.appName).toString()
+            if (clipboardManager.copy(label, summary) == CopyResult.FeedbackNotShown) {
+                sendEvent(AppDetailEvent.ShowFeedback(AppDetailFeedback.SummaryCopied))
+            }
+        }
+    }
+
+    private fun shareSummary() {
+        withLoadedState { state ->
+            sendEvent(AppDetailEvent.ShareSummary(state.toSummaryText(resourcesManager)))
         }
     }
 

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
@@ -1,6 +1,5 @@
 package sk.styk.martin.apkanalyzer.feature.appdetail.impl
 
-import android.content.Context
 import android.net.Uri
 import android.os.Build
 import androidx.lifecycle.ViewModel
@@ -9,7 +8,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -59,7 +57,7 @@ internal class AppDetailViewModel @AssistedInject constructor(
     private val temporaryApkManager: TemporaryApkManager,
     private val recentlyViewedAppsRepository: RecentlyViewedAppsRepository,
     private val clipboardManager: ClipboardManager,
-    @ApplicationContext private val context: Context,
+    private val summaryTextFormatter: AppSummaryTextFormatter,
 ) : ViewModel() {
 
     @AssistedFactory
@@ -99,6 +97,8 @@ internal class AppDetailViewModel @AssistedInject constructor(
             is AppDetailAction.ExportApk -> requestDocument(AppDetailExport.Apk)
 
             is AppDetailAction.SaveIcon -> requestDocument(AppDetailExport.Icon)
+
+            is AppDetailAction.ViewSummary -> viewSummary()
 
             is AppDetailAction.CopySummary -> copySummary()
 
@@ -166,10 +166,16 @@ internal class AppDetailViewModel @AssistedInject constructor(
         }
     }
 
+    private fun viewSummary() {
+        withLoadedState { state ->
+            sendEvent(AppDetailEvent.ShowSummaryPreview(summaryTextFormatter.summary(state)))
+        }
+    }
+
     private fun copySummary() {
         withLoadedState { state ->
-            val summary = state.toSummaryText(context)
-            val label = context.getString(R.string.app_detail_summary_clip_label, state.appName)
+            val summary = summaryTextFormatter.summary(state)
+            val label = summaryTextFormatter.clipLabel(state.appName)
             if (clipboardManager.copy(label, summary) == CopyResult.FeedbackNotShown) {
                 sendEvent(AppDetailEvent.ShowFeedback(AppDetailFeedback.SummaryCopied))
             }
@@ -178,7 +184,7 @@ internal class AppDetailViewModel @AssistedInject constructor(
 
     private fun shareSummary() {
         withLoadedState { state ->
-            sendEvent(AppDetailEvent.ShareSummary(state.toSummaryText(context)))
+            sendEvent(AppDetailEvent.ShareSummary(summaryTextFormatter.summary(state)))
         }
     }
 
@@ -272,7 +278,7 @@ private const val MAX_REQUIREMENT_PREVIEWS = 6
 
 private fun AppDetailState.Loaded.withComputedBadges(now: Instant): AppDetailState.Loaded = copy(
     badges = buildList {
-        if (source == AppSource.Unknown.name) add(AppDetailBadge.Sideloaded)
+        if (source == AppSource.Unknown) add(AppDetailBadge.Sideloaded)
         if (insights.any { it is AppDetailInsight.SensitivePermission }) add(AppDetailBadge.DangerousPermissions)
         lastUsedTime?.let { lastUsed ->
             if (lastUsed.isBefore(now.minus(AppClassificationThresholds.UNUSED_PERIOD))) add(AppDetailBadge.Unused)
@@ -289,7 +295,7 @@ private fun AppDetailState.Loaded.withComputedBadges(now: Instant): AppDetailSta
         lastUsedTime?.let { lastUsed ->
             if (lastUsed.isAfter(now.minus(AppClassificationThresholds.RECENTLY_USED_DAYS.days.toJavaDuration()))) add(AppDetailBadge.RecentlyUsed)
         }
-        if (source == AppSource.GooglePlay.name) add(AppDetailBadge.GooglePlay)
+        if (source == AppSource.GooglePlay) add(AppDetailBadge.GooglePlay)
     }.take(MAX_BADGES).toImmutableList(),
 )
 
@@ -317,7 +323,7 @@ private fun AppDetail.toLoadedState(permissionLabelProvider: PermissionLabelProv
         uid = info.uid,
         description = info.description,
         isSystemApp = info.isSystemApp,
-        source = info.source.name,
+        source = info.source,
         apkDirectory = info.apkDirectory,
         dataDirectory = info.dataDirectory,
         apkSize = info.apkSize,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
@@ -1,5 +1,6 @@
 package sk.styk.martin.apkanalyzer.feature.appdetail.impl
 
+import android.content.Context
 import android.net.Uri
 import android.os.Build
 import androidx.lifecycle.ViewModel
@@ -8,6 +9,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,7 +38,6 @@ import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
-import sk.styk.martin.apkanalyzer.core.common.resources.ResourcesManager
 import sk.styk.martin.apkanalyzer.core.userpreferences.RecentlyViewedAppsRepository
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.ApkFileLifetime
 import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
@@ -58,7 +59,7 @@ internal class AppDetailViewModel @AssistedInject constructor(
     private val temporaryApkManager: TemporaryApkManager,
     private val recentlyViewedAppsRepository: RecentlyViewedAppsRepository,
     private val clipboardManager: ClipboardManager,
-    private val resourcesManager: ResourcesManager,
+    @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
     @AssistedFactory
@@ -167,8 +168,8 @@ internal class AppDetailViewModel @AssistedInject constructor(
 
     private fun copySummary() {
         withLoadedState { state ->
-            val summary = state.toSummaryText(resourcesManager)
-            val label = resourcesManager.getString(R.string.app_detail_summary_clip_label, state.appName).toString()
+            val summary = state.toSummaryText(context)
+            val label = context.getString(R.string.app_detail_summary_clip_label, state.appName)
             if (clipboardManager.copy(label, summary) == CopyResult.FeedbackNotShown) {
                 sendEvent(AppDetailEvent.ShowFeedback(AppDetailFeedback.SummaryCopied))
             }
@@ -177,7 +178,7 @@ internal class AppDetailViewModel @AssistedInject constructor(
 
     private fun shareSummary() {
         withLoadedState { state ->
-            sendEvent(AppDetailEvent.ShareSummary(state.toSummaryText(resourcesManager)))
+            sendEvent(AppDetailEvent.ShareSummary(state.toSummaryText(context)))
         }
     }
 

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
@@ -46,6 +46,7 @@ import kotlin.time.toJavaDuration
 
 private const val TAG = "AppDetailViewModel"
 
+@Suppress("TooManyFunctions")
 @HiltViewModel(assistedFactory = AppDetailViewModel.Factory::class)
 internal class AppDetailViewModel @AssistedInject constructor(
     @Assisted private val appDetailInput: AppDetailInput,
@@ -88,6 +89,7 @@ internal class AppDetailViewModel @AssistedInject constructor(
         loadDetail()
     }
 
+    @Suppress("CyclomaticComplexMethod")
     fun onAction(action: AppDetailAction) {
         when (action) {
             is AppDetailAction.Retry -> loadDetail()

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppSummaryTextFormatter.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppSummaryTextFormatter.kt
@@ -1,0 +1,6 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl
+
+internal interface AppSummaryTextFormatter {
+    fun summary(state: AppDetailState.Loaded): String
+    fun clipLabel(appName: String): String
+}

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppSummaryTextFormatterImpl.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppSummaryTextFormatterImpl.kt
@@ -1,0 +1,73 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl
+
+import android.content.Context
+import androidx.annotation.PluralsRes
+import dagger.hilt.android.qualifiers.ApplicationContext
+import sk.styk.martin.apkanalyzer.core.apps.model.CertificateTrustLevel
+import sk.styk.martin.apkanalyzer.core.common.model.AppSource
+import javax.inject.Inject
+
+internal class AppSummaryTextFormatterImpl @Inject constructor(@ApplicationContext private val context: Context) : AppSummaryTextFormatter {
+
+    override fun summary(state: AppDetailState.Loaded): String = with(state) {
+        buildList {
+            add(context.getString(R.string.app_detail_summary_header, appName, packageName.value))
+            add(summaryLine(R.string.app_detail_version, versionSummary()))
+            minSdkSummary()?.let { add(summaryLine(R.string.general_info_min_sdk, it)) }
+            targetSdkSummary()?.let { add(summaryLine(R.string.general_info_target_sdk, it)) }
+            add(summaryLine(R.string.general_info_install_source, sourceSummary()))
+            add(summaryLine(R.string.app_detail_apk_size, apkSize.formatted()))
+            totalSize?.let { add(summaryLine(R.string.app_detail_total_size, it.formatted())) }
+            signingSummary()?.let { add(summaryLine(R.string.app_detail_summary_signing_label, it)) }
+            add(summaryLine(R.string.app_detail_permissions_section, permissionsSummary()))
+        }.joinToString("\n")
+    }
+
+    override fun clipLabel(appName: String): String = context.getString(R.string.app_detail_summary_clip_label, appName)
+
+    private fun summaryLine(labelRes: Int, value: String): String = context.getString(R.string.app_detail_summary_line, context.getString(labelRes), value)
+
+    private fun AppDetailState.Loaded.versionSummary(): String = versionName?.let { context.getString(R.string.app_detail_summary_version, it, versionCode) }
+        ?: versionCode.toString()
+
+    private fun AppDetailState.Loaded.minSdkSummary(): String? = when {
+        minSdkLabel != null -> minSdkLabel
+        minSdkVersion != null -> context.getString(R.string.app_detail_sdk_version_no_label, minSdkVersion)
+        else -> null
+    }
+
+    private fun AppDetailState.Loaded.targetSdkSummary(): String? = when {
+        targetSdkLabel != null -> targetSdkLabel
+        targetSdkVersion != null -> context.getString(R.string.app_detail_sdk_version_no_label, targetSdkVersion)
+        else -> null
+    }
+
+    private fun AppDetailState.Loaded.sourceSummary(): String = when (source) {
+        AppSource.GooglePlay -> context.getString(R.string.general_info_install_source_google_play)
+        AppSource.SystemPreinstalled -> context.getString(R.string.general_info_install_source_system)
+        AppSource.Unknown -> context.getString(R.string.general_info_install_source_unknown)
+    }
+
+    private fun AppDetailState.Loaded.signingSummary(): String? {
+        val cert = certificate ?: return null
+        return when (cert.trustLevel) {
+            CertificateTrustLevel.Debug -> context.getString(R.string.app_detail_certificate_debug)
+            CertificateTrustLevel.Valid -> cert.signerDisplayName ?: context.getString(R.string.certificates_self_signed)
+        }
+    }
+
+    private fun AppDetailState.Loaded.permissionsSummary(): String = grantedDangerousPermissionsCount?.let { granted ->
+        context.getString(
+            R.string.app_detail_summary_permissions_granted,
+            permissionCountSummary(totalPermissionsCount, R.plurals.app_detail_summary_permissions_requested),
+            permissionCountSummary(dangerousPermissionsCount, R.plurals.app_detail_summary_permissions_dangerous),
+            permissionCountSummary(granted, R.plurals.app_detail_summary_permissions_granted_count),
+        )
+    } ?: context.getString(
+        R.string.app_detail_summary_permissions,
+        permissionCountSummary(totalPermissionsCount, R.plurals.app_detail_summary_permissions_requested),
+        permissionCountSummary(dangerousPermissionsCount, R.plurals.app_detail_summary_permissions_dangerous),
+    )
+
+    private fun permissionCountSummary(count: Int, @PluralsRes pluralsRes: Int): String = context.resources.getQuantityString(pluralsRes, count, count)
+}

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/components/AppSummaryBottomSheet.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/components/AppSummaryBottomSheet.kt
@@ -1,0 +1,101 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.BottomSheet
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Button
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Text
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.TextButton
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.Shapes
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.R
+
+@Composable
+internal fun AppSummaryBottomSheet(
+    summary: String,
+    onCopy: () -> Unit,
+    onShare: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BottomSheet(
+        onDismiss = onDismiss,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.app_detail_summary_sheet_title),
+                style = AppTheme.typography.titleMedium,
+                color = AppTheme.colors.onSurface,
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 320.dp)
+                    .clip(Shapes.CardShape)
+                    .background(AppTheme.colors.surfaceVariant)
+                    .clickable(onClick = onCopy)
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+            ) {
+                Text(
+                    text = summary,
+                    style = AppTheme.typography.monospace,
+                    color = AppTheme.colors.onSurfaceVariant,
+                )
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                TextButton(
+                    text = stringResource(R.string.app_detail_action_copy_summary),
+                    onClick = onCopy,
+                    modifier = Modifier.weight(1f),
+                )
+                Button(
+                    text = stringResource(R.string.app_detail_action_share_summary),
+                    onClick = onShare,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AppSummaryBottomSheetPreview() {
+    ApkAnalyzerTheme {
+        AppSummaryBottomSheet(
+            summary = "Spotify (com.spotify.music)\n" +
+                "Version: 9.4.12 (90412)\n" +
+                "APK Size: 152 MB\n" +
+                "Permissions: 32 requested permissions · 6 dangerous permissions · 4 granted permissions",
+            onCopy = {},
+            onShare = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/di/AppDetailModule.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/di/AppDetailModule.kt
@@ -1,0 +1,15 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.AppSummaryTextFormatter
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.AppSummaryTextFormatterImpl
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface AppDetailModule {
+    @Binds
+    fun bindAppSummaryTextFormatter(impl: AppSummaryTextFormatterImpl): AppSummaryTextFormatter
+}

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Export APK</string>
     <string name="app_detail_action_save_icon">Save Icon</string>
+    <string name="app_detail_action_copy_summary">Copy Summary</string>
+    <string name="app_detail_action_share_summary">Share Summary</string>
     <string name="app_detail_action_play_store">Play Store</string>
     <string name="app_detail_action_app_info">App Info</string>
     <string name="app_detail_action_saving">Saving…</string>
@@ -44,6 +46,15 @@
     <string name="app_detail_apk_save_failed">The APK could not be saved</string>
     <string name="app_detail_icon_save_failed">The icon could not be saved</string>
     <string name="app_detail_document_picker_unavailable">No app can choose a save location</string>
+    <string name="app_detail_summary_copied">Summary copied to clipboard</string>
+    <string name="app_detail_summary_clip_label">%1$s summary</string>
+    <string name="app_detail_share_unavailable">No app can handle sharing</string>
+    <string name="app_detail_summary_line">%1$s: %2$s</string>
+    <string name="app_detail_summary_header">%1$s (%2$s)</string>
+    <string name="app_detail_summary_version">%1$s (%2$d)</string>
+    <string name="app_detail_summary_signing_label">Signing</string>
+    <string name="app_detail_summary_permissions">%1$d requested · %2$d dangerous</string>
+    <string name="app_detail_summary_permissions_granted">%1$d requested · %2$d dangerous · %3$d granted</string>
     <string name="app_detail_permissions_section">Permissions</string>
     <string name="app_detail_total_permissions">Total Permissions</string>
     <string name="app_detail_dangerous_permissions">Dangerous Permissions</string>

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -20,8 +20,10 @@
     <string name="app_detail_action_manifest">Manifest</string>
     <string name="app_detail_action_export_apk">Export APK</string>
     <string name="app_detail_action_save_icon">Save Icon</string>
-    <string name="app_detail_action_copy_summary">Copy Summary</string>
-    <string name="app_detail_action_share_summary">Share Summary</string>
+    <string name="app_detail_action_summary">Summary</string>
+    <string name="app_detail_action_copy_summary">Copy</string>
+    <string name="app_detail_action_share_summary">Share</string>
+    <string name="app_detail_summary_sheet_title">App summary</string>
     <string name="app_detail_action_play_store">Play Store</string>
     <string name="app_detail_action_app_info">App Info</string>
     <string name="app_detail_action_saving">Saving…</string>

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -53,8 +53,20 @@
     <string name="app_detail_summary_header">%1$s (%2$s)</string>
     <string name="app_detail_summary_version">%1$s (%2$d)</string>
     <string name="app_detail_summary_signing_label">Signing</string>
-    <string name="app_detail_summary_permissions">%1$d requested · %2$d dangerous</string>
-    <string name="app_detail_summary_permissions_granted">%1$d requested · %2$d dangerous · %3$d granted</string>
+    <string name="app_detail_summary_permissions">%1$s · %2$s</string>
+    <string name="app_detail_summary_permissions_granted">%1$s · %2$s · %3$s</string>
+    <plurals name="app_detail_summary_permissions_requested">
+        <item quantity="one">%1$d requested permission</item>
+        <item quantity="other">%1$d requested permissions</item>
+    </plurals>
+    <plurals name="app_detail_summary_permissions_dangerous">
+        <item quantity="one">%1$d dangerous permission</item>
+        <item quantity="other">%1$d dangerous permissions</item>
+    </plurals>
+    <plurals name="app_detail_summary_permissions_granted_count">
+        <item quantity="one">%1$d granted permission</item>
+        <item quantity="other">%1$d granted permissions</item>
+    </plurals>
     <string name="app_detail_permissions_section">Permissions</string>
     <string name="app_detail_total_permissions">Total Permissions</string>
     <string name="app_detail_dangerous_permissions">Dangerous Permissions</string>


### PR DESCRIPTION
## Summary
- Adds two new Quick Actions to the App Detail hub: Copy Summary and Share Summary, next to Export APK / Save Icon
- Copy uses the existing `ClipboardManager` (with a manual "copied" toast fallback pre-Android 13); Share sends a plain `Intent.ACTION_SEND` (`text/plain`) wrapped in `Intent.createChooser`, handled through the screen's existing Event -> LaunchedEffect pattern
- Both build the same compact plain-text summary via a new pure formatter (`AppDetailState.Loaded.toSummaryText`) in `AppDetailFormatting.kt`, using the injectable `ResourcesManager` so the text stays independent of the Compose layer
- Summary covers, in order: app name + package, version name (code), min/target SDK (using the existing friendly labels, falling back to `API N` when no label is available), install source, APK size, total size (omitted in APK-file mode), signing (signer organization, else "Debug certificate" / "Self-signed"), and permission counts (`X requested · Y dangerous · Z granted`, granted omitted in APK-file mode)
- Adds a `Share` icon constant to `ApkAnalyzerIcons` (Copy already existed)
- Marks FR-26 done: removes its row from `docs/product/roadmap.md` (§1.5, "R0 remaining", and the Release Plan row) and adds it to `docs/product/shipped.md` §1.5

## Test plan
- [x] `./gradlew :feature:app-detail:impl:compileDebugKotlin`
- [x] `./gradlew spotlessApply`
- [ ] Manual: open App Detail on an installed app and an APK file, tap Copy Summary and Share Summary, confirm the clipboard/share sheet content and that Total Size / granted-count lines are omitted in APK-file mode