### PR TITLE
Disable Detekt LongMethod rule

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -14,7 +14,7 @@ complexity:
   LongParameterList:
     active: false
   LongMethod:
-    severity: info
+    active: false
   NestedBlockDepth:
     severity: error
   TooManyFunctions:


### PR DESCRIPTION
Compose screens frequently exceed the generic method-length threshold, and the current Detekt version cannot exclude `@Composable` functions from `LongMethod`.

Disable the rule globally to remove noisy findings without adding custom rule infrastructure or per-function suppressions.