### PR TITLE
Add storage breakdown screen (FR-37)

### DIFF
--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -40,13 +40,13 @@ import sk.styk.martin.apkanalyzer.core.apps.permissions.resolveProtectionLevel
 import sk.styk.martin.apkanalyzer.core.apps.sdkversion.SdkVersionResolver
 import sk.styk.martin.apkanalyzer.core.apps.signing.ApkSigningBlockAnalyzer
 import sk.styk.martin.apkanalyzer.core.apps.signing.CertificateExtractor
+import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageBreakdown
 import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageStatsRepository
 import sk.styk.martin.apkanalyzer.core.apps.usagestats.UsageStatsRepository
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
-import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import java.io.File
 import java.time.Instant
@@ -96,7 +96,9 @@ internal class AppDetailRepositoryImpl @Inject constructor(
 
     private suspend fun installedPackageDetails(packageName: PackageName): Result<AppDetail> {
         val cacheKey = CacheKey.InstalledPackage(packageName)
-        cache[cacheKey]?.let { return Result.success(it) }
+        cache[cacheKey]?.let { cached ->
+            return Result.success(cached.withStorageBreakdown(storageStatsRepository.queryBreakdown(packageName)))
+        }
         Logger.d(TAG, "Loading details of $packageName")
         return runCatchingCancellable {
             val reference = AppReference.InstalledPackage(packageName)
@@ -107,7 +109,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
                 packageInfo = packageInfo,
                 intentFiltersByComponent = intentFilters.getOrDefault(emptyMap()),
                 areIntentFiltersAvailable = intentFilters.isSuccess,
-                totalSize = storageStatsRepository.queryTotalSize(packageName),
+                storageBreakdown = storageStatsRepository.queryBreakdown(packageName),
                 lastUsedTime = usageStatsRepository.queryLastUsedTime(packageName),
             )
         }.onSuccess { cache[cacheKey] = it }
@@ -135,11 +137,11 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         packageInfo: PackageInfo,
         intentFiltersByComponent: Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>,
         areIntentFiltersAvailable: Boolean,
-        totalSize: AppSize? = null,
+        storageBreakdown: StorageBreakdown? = null,
         lastUsedTime: Instant? = null,
     ) = AppDetail(
         analysisMode = analysisMode,
-        info = getGeneralData(packageInfo, totalSize, lastUsedTime),
+        info = getGeneralData(packageInfo, storageBreakdown, lastUsedTime),
         signing = certificateExtractor.getAppSigning(packageInfo)
             .copy(
                 signingSchemeVersions = packageInfo.applicationInfo?.sourceDir
@@ -164,7 +166,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
 
     private fun getGeneralData(
         packageInfo: PackageInfo,
-        totalSize: AppSize? = null,
+        storageBreakdown: StorageBreakdown? = null,
         lastUsedTime: Instant? = null,
     ): AppInfo {
         val applicationInfo = packageInfo.applicationInfo
@@ -197,7 +199,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             minSdkLabel = sdkVersionResolver.resolveVersion(minSdk),
             targetSdkVersion = applicationInfo?.targetSdkVersion,
             targetSdkLabel = sdkVersionResolver.resolveVersion(applicationInfo?.targetSdkVersion),
-            totalSize = totalSize,
+            storageBreakdown = storageBreakdown,
             lastUsedTime = lastUsedTime,
             installedSplits = readInstalledSplits(applicationInfo),
         )
@@ -319,6 +321,8 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             else -> Feature.Hardware(name = name, version = featureInfo.version, isRequired = isRequired)
         }
     }
+
+    private fun AppDetail.withStorageBreakdown(breakdown: StorageBreakdown?): AppDetail = copy(info = info.copy(storageBreakdown = breakdown))
 
     private fun ApplicationInfo?.hasFlag(flag: Int): Boolean = this?.flags?.and(flag) != 0
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/AppInfo.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/model/AppInfo.kt
@@ -2,6 +2,7 @@ package sk.styk.martin.apkanalyzer.core.apps.model
 
 import sk.styk.martin.apkanalyzer.core.apps.installsource.InstallSourceChain
 import sk.styk.martin.apkanalyzer.core.apps.packaging.InstalledSplitApk
+import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageBreakdown
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
@@ -33,7 +34,7 @@ data class AppInfo(
     val minSdkLabel: String? = null,
     val targetSdkVersion: Int? = null,
     val targetSdkLabel: String? = null,
-    val totalSize: AppSize? = null,
+    val storageBreakdown: StorageBreakdown? = null,
     val lastUsedTime: Instant? = null,
     val installedSplits: List<InstalledSplitApk> = emptyList(),
 )

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageBreakdown.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageBreakdown.kt
@@ -1,0 +1,11 @@
+package sk.styk.martin.apkanalyzer.core.apps.storagestats
+
+import sk.styk.martin.apkanalyzer.core.common.model.AppSize
+
+data class StorageBreakdown(
+    val appBytes: AppSize,
+    val dataBytes: AppSize,
+    val cacheBytes: AppSize,
+) {
+    val total: AppSize get() = appBytes + dataBytes + cacheBytes
+}

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepository.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepository.kt
@@ -8,5 +8,5 @@ interface StorageStatsRepository {
     val isPermissionGranted: StateFlow<Boolean>
     val totalSizes: StateFlow<Map<PackageName, AppSize>>
     fun requestTotalSizes(packageNames: List<PackageName>)
-    suspend fun queryTotalSize(packageName: PackageName): AppSize?
+    suspend fun queryBreakdown(packageName: PackageName): StorageBreakdown?
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -64,8 +64,8 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun queryTotalSize(packageName: PackageName): AppSize? = totalSizes.value[packageName] ?: if (checkPermission()) {
-        queryPackageSize(UserHandle.getUserHandleForUid(Process.myUid()), packageName)
+    override suspend fun queryBreakdown(packageName: PackageName): StorageBreakdown? = if (checkPermission()) {
+        queryPackageBreakdown(UserHandle.getUserHandleForUid(Process.myUid()), packageName)
     } else {
         null
     }
@@ -78,14 +78,18 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
         Logger.d(INSTALLED_APPS, "Load apps total size")
         val user = UserHandle.getUserHandleForUid(Process.myUid())
         totalSizes.value = packageNames.mapNotNull { packageName ->
-            queryPackageSize(user, packageName)?.let { packageName to it }
+            queryPackageBreakdown(user, packageName)?.let { packageName to it.total }
         }.toMap()
         Logger.d(INSTALLED_APPS, "Apps total size loaded")
     }
 
-    private fun queryPackageSize(user: UserHandle, packageName: PackageName): AppSize? = try {
+    private fun queryPackageBreakdown(user: UserHandle, packageName: PackageName): StorageBreakdown? = try {
         val stats = storageStatsManager.queryStatsForPackage(StorageManager.UUID_DEFAULT, packageName.value, user)
-        stats.appBytes.bytes + stats.dataBytes.bytes + stats.cacheBytes.bytes
+        StorageBreakdown(
+            appBytes = stats.appBytes.bytes,
+            dataBytes = stats.dataBytes.bytes,
+            cacheBytes = stats.cacheBytes.bytes,
+        )
     } catch (_: PackageManager.NameNotFoundException) {
         null
     } catch (_: IOException) {

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/model/AppDataPermission.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/model/AppDataPermission.kt
@@ -1,0 +1,6 @@
+package sk.styk.martin.apkanalyzer.core.common.model
+
+sealed interface AppDataPermission {
+    data object UsageAccess : AppDataPermission
+    data object StorageAccess : AppDataPermission
+}

--- a/core/ui-library/AGENTS.md
+++ b/core/ui-library/AGENTS.md
@@ -48,9 +48,11 @@ name** — check here before calling one:
 | `LoadingSpinner` | `LoadingSpinner.kt` |
 | `MultiSelectorChip` | `MultiSelectorChip.kt` |
 | `NavigationBar` (+ `NavigationBarItem` data class) | `NavigationBar.kt` |
+| `PermissionRationaleBottomSheet` | `PermissionRationaleBottomSheet.kt` |
 | `RangeSlider` | `RangeSlider.kt` |
 | `SearchBarActive` | `SearchBarActive.kt` |
 | **`InactiveSearchBar`** — note the inverted name | `SearchBarInactive.kt` |
+| `SegmentedBarChart` (+ `BarChartSegment` data class) | `SegmentedBarChart.kt` |
 | `SelectorChip` | `SelectorChip.kt` |
 | `SkeletonBox` | `SkeletonBox.kt` |
 | `Switch` | `Switch.kt` |

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/PermissionRationaleBottomSheet.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/PermissionRationaleBottomSheet.kt
@@ -1,6 +1,4 @@
-@file:Suppress("MatchingDeclarationName")
-
-package sk.styk.martin.apkanalyzer.feature.apps.impl.components
+package sk.styk.martin.apkanalyzer.core.uilibrary.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -11,34 +9,24 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import sk.styk.martin.apkanalyzer.core.uilibrary.components.BottomSheet
-import sk.styk.martin.apkanalyzer.core.uilibrary.components.Button
-import sk.styk.martin.apkanalyzer.core.uilibrary.components.Icon
-import sk.styk.martin.apkanalyzer.core.uilibrary.components.Text
 import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
 
-@Immutable
-sealed interface AppDataPermission {
-    data object UsageAccess : AppDataPermission
-    data object StorageAccess : AppDataPermission
-}
-
 @Composable
-internal fun PermissionRationaleBottomSheet(
+fun PermissionRationaleBottomSheet(
     title: String,
     description: String,
     openSettingsLabel: String,
     onOpenSettings: () -> Unit,
     onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    BottomSheet(onDismiss = onDismiss) {
+    BottomSheet(onDismiss = onDismiss, modifier = modifier) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/SegmentedBarChart.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/SegmentedBarChart.kt
@@ -1,0 +1,109 @@
+package sk.styk.martin.apkanalyzer.core.uilibrary.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
+
+@Immutable
+data class BarChartSegment(val value: Float, val color: Color)
+
+private const val REVEAL_DURATION_MS = 700
+private const val SEGMENT_GAP_DP = 3
+
+@Composable
+fun SegmentedBarChart(
+    segments: ImmutableList<BarChartSegment>,
+    modifier: Modifier = Modifier,
+    height: Dp = 20.dp,
+) {
+    val trackColor = AppTheme.colors.surfaceVariant
+    val reveal = remember { Animatable(0f) }
+
+    LaunchedEffect(segments) {
+        reveal.snapTo(0f)
+        reveal.animateTo(1f, animationSpec = tween(durationMillis = REVEAL_DURATION_MS, easing = FastOutSlowInEasing))
+    }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height),
+    ) {
+        val total = segments.sumOf { it.value.toDouble() }.toFloat()
+        val gapPx = SEGMENT_GAP_DP.dp.toPx()
+        val minWidthPx = size.height
+        val barPath = Path().apply {
+            addRoundRect(RoundRect(0f, 0f, size.width, size.height, CornerRadius(size.height / 2)))
+        }
+        clipPath(barPath) {
+            drawRect(color = trackColor, size = size)
+            clipRect(right = size.width * reveal.value) {
+                var startX = 0f
+                segments.forEach { segment ->
+                    val fraction = if (total > 0f) segment.value / total else 0f
+                    val segmentWidth = size.width * fraction
+                    if (segmentWidth > 0f) {
+                        val drawWidth = (segmentWidth - gapPx).coerceAtLeast(minWidthPx)
+                        drawRect(
+                            color = segment.color,
+                            topLeft = Offset(startX, 0f),
+                            size = Size(drawWidth, size.height),
+                        )
+                        startX += maxOf(segmentWidth, drawWidth + gapPx)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SegmentedBarChartPreview() {
+    ApkAnalyzerTheme {
+        SegmentedBarChart(
+            segments = persistentListOf(
+                BarChartSegment(value = 620f, color = AppTheme.colors.primary),
+                BarChartSegment(value = 240f, color = AppTheme.colors.secondary),
+                BarChartSegment(value = 90f, color = AppTheme.colors.tertiary),
+            ),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SegmentedBarChartDarkPreview() {
+    ApkAnalyzerTheme(isDarkTheme = true) {
+        SegmentedBarChart(
+            segments = persistentListOf(
+                BarChartSegment(value = 620f, color = AppTheme.colors.primary),
+                BarChartSegment(value = 240f, color = AppTheme.colors.secondary),
+                BarChartSegment(value = 90f, color = AppTheme.colors.tertiary),
+            ),
+        )
+    }
+}

--- a/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/SegmentedBarChart.kt
+++ b/core/ui-library/src/main/kotlin/sk/styk/martin/apkanalyzer/core/uilibrary/components/SegmentedBarChart.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MatchingDeclarationName")
+
 package sk.styk.martin.apkanalyzer.core.uilibrary.components
 
 import androidx.compose.animation.core.Animatable

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -33,7 +33,7 @@ dropped, its ID is retired.
 
 **This file tracks open work only.** Once an item reaches Done or Retired, its row moves to
 [shipped.md](shipped.md) so this document doesn't fill up with finished work — look there for an ID
-that isn't listed here. Section numbers can skip (there's no `1.1`, `1.3`, `1.4`, or `1.6` below)
+that isn't listed here. Section numbers can skip (there's no `1.1`, `1.3`, `1.4`, `1.5`, or `1.6` below)
 because those sections shipped in full and moved out entirely; numbers never get reassigned to keep
 cross-references stable.
 
@@ -60,12 +60,6 @@ section has shipped except:
 | FR-17 | Exported components view            | Partial | Exported/Unprotected filter chips ship in the Components screen (`FR-13`), backed by both intent filters (`EX-07`) and content-provider path permissions (`EX-08`), both done. Still a technical filter, not a risk verdict — needs a deliberate hub rule (see `RI-03`) before exposure becomes a "Worth knowing" finding |
 | FR-18 | Custom permission audit             | Partial | Permissions screen's `Defined` scope lists the app's declared permissions with full detail sheets; no audit judgment (e.g. protection-level risk) applied yet |
 
-### 1.5 Export & Share
-
-| ID    | Item                        | Status | Notes                                                    |
-|-------|-----------------------------|--------|-----------------------------------------------------------|
-| FR-27 | Launch a component          | Todo   | `startForeignActivity` exists and is unused               |
-
 ### 1.7 Invisible Infrastructure
 
 | ID    | Item                                | Status | Notes                                                                                                          |
@@ -80,11 +74,10 @@ doing in R0 rather than later.
 
 | ID    | Item                              | Status  | Why it matters                                                                                       |
 |-------|-----------------------------------|---------|---------------------------------------------------------------------------------------------------------|
-| FR-37 | Storage breakdown                 | Todo    | `StorageStats` already gives app/data/cache; only the total is used                                  |
 | FR-44 | Declared `<uses-library>` entries | Backlog | Name and `android:required`, from the manifest for APK files and `sharedLibraryFiles` for installed apps. Deprioritized: most apps declare zero entries, and the ones that do are boilerplate (`android.test.runner`) or legacy trivia (`org.apache.http.legacy`) — the value is screen completeness, not a real finding. Revisit if a concrete tracker/risk signal ends up needing it |
 
 **R0 remaining:** FR-17, FR-18 (Partial — blocked on `RI-03`, a Pro/R1 item), CE-06 (Backlog),
-FR-27, FR-31 (blocked on `OQ-01`), FR-37, FR-44 (Backlog), plus `EN`.
+FR-31 (blocked on `OQ-01`), FR-44 (Backlog), plus `EN`.
 Everything else originally scoped for R0 has shipped — see [shipped.md](shipped.md).
 
 ---
@@ -260,7 +253,7 @@ interpretation (that's `RP`) but *tedium removed*: nobody opens 300 app reports 
 
 | ID | Release         | Contents                                                                              | Duration       | Cumulative |
 |----|-----------------|-----------------------------------------------------------------------------------------|----------------|------------|
-| R0 | Free Rework     | Remaining: FR-17, FR-18, CE-06, FR-27, FR-31, FR-37, FR-44, plus `EN` — rest shipped, see [shipped.md](shipped.md) | ~7–8 weeks     | Week 8     |
+| R0 | Free Rework     | Remaining: FR-17, FR-18, CE-06, FR-31, FR-44, plus `EN` — rest shipped, see [shipped.md](shipped.md) | ~7–8 weeks     | Week 8     |
 | R1 | Pro Launch      | `HI`, `RI`, `TR`, `RP`, `CP`                                                             | ~5.5–6.5 weeks | Week 15    |
 | R2 | Bulk Tools      | `BX`                                                                                     | ~1.5–2 weeks   | Week 17    |
 | R3 | Optional polish | OP-01 … OP-03                                                                            | as-needed      | Ongoing    |

--- a/docs/product/shipped.md
+++ b/docs/product/shipped.md
@@ -26,7 +26,8 @@ implemented per `CE-05`. That freed the bottom-nav slot Pillar 1's What Changed 
 
 FR-10 Detail overview + badges · FR-11 General info screen · FR-12 Permissions view (per app) ·
 FR-13 Components views · FR-14 Certificate detail view · FR-15 Features (uses-feature) view ·
-FR-16 Manifest viewer · FR-45 Split APK files screen · FR-46 Native libraries screen
+FR-16 Manifest viewer · FR-45 Split APK files screen · FR-46 Native libraries screen · FR-37 Storage
+breakdown screen
 
 ## 1.3 APK File Analysis
 
@@ -45,7 +46,8 @@ natively once statistics and browse stopped being separate screens.
 
 ## 1.5 Export & Share
 
-FR-24 APK export / share · FR-25 Icon export · FR-26 Copy / share app summary
+FR-24 APK export / share · FR-25 Icon export · FR-26 Copy / share app summary · FR-27 Launch a
+component
 
 ## 1.6 App & UI
 

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/AppDetailViewModel.kt
@@ -382,7 +382,7 @@ private fun AppDetail.toLoadedState(permissionLabelProvider: PermissionLabelProv
                 trustLevel = cert.trustLevel,
             )
         },
-        totalSize = info.totalSize,
+        totalSize = info.storageBreakdown?.total,
         lastUsedTime = info.lastUsedTime,
         installedSplitsCount = info.installedSplits.size,
         hasNativeLibraries = nativeLibraries.hasNativeCode,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoScreen.kt
@@ -28,6 +28,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
 import sk.styk.martin.apkanalyzer.core.apps.installsource.InstallSourceChain
+import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.megabytes
@@ -55,6 +56,7 @@ internal fun GeneralInfoScreen(
     onBack: () -> Unit,
     onNavigateToSplitApks: () -> Unit,
     onNavigateToNativeLibraries: () -> Unit,
+    onNavigateToStorage: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: GeneralInfoViewModel = hiltViewModel { factory: GeneralInfoViewModel.Factory ->
         factory.create(appDetailInput)
@@ -77,6 +79,7 @@ internal fun GeneralInfoScreen(
         onBack = onBack,
         onNavigateToSplitApks = onNavigateToSplitApks,
         onNavigateToNativeLibraries = onNavigateToNativeLibraries,
+        onNavigateToStorage = onNavigateToStorage,
         modifier = modifier,
     )
 }
@@ -88,6 +91,7 @@ private fun GeneralInfoContent(
     onBack: () -> Unit,
     onNavigateToSplitApks: () -> Unit,
     onNavigateToNativeLibraries: () -> Unit,
+    onNavigateToStorage: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -109,6 +113,7 @@ private fun GeneralInfoContent(
                 onAction = onAction,
                 onNavigateToSplitApks = onNavigateToSplitApks,
                 onNavigateToNativeLibraries = onNavigateToNativeLibraries,
+                onNavigateToStorage = onNavigateToStorage,
             )
         }
     }
@@ -120,6 +125,7 @@ private fun LoadedContent(
     onAction: (GeneralInfoAction) -> Unit,
     onNavigateToSplitApks: () -> Unit,
     onNavigateToNativeLibraries: () -> Unit,
+    onNavigateToStorage: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var rationaleRow by remember { mutableStateOf<InfoRow?>(null) }
@@ -349,6 +355,14 @@ private fun LoadedContent(
                 onShowRationale = { rationaleRow = it },
                 onCopy = onCopy,
             )
+            if (state.analysisMode == AppDetail.AnalysisMode.InstalledPackage) {
+                NavigableInfoRowItem(
+                    label = stringResource(R.string.general_info_storage),
+                    value = state.totalSize?.formatted() ?: stringResource(R.string.general_info_storage_permission_needed),
+                    onClick = onNavigateToStorage,
+                    onCopy = onCopy,
+                )
+            }
             if (state.installedSplitsCount > 0) {
                 NavigableInfoRowItem(
                     label = stringResource(R.string.general_info_split_apks),
@@ -358,15 +372,6 @@ private fun LoadedContent(
                         state.installedSplitsCount,
                     ),
                     onClick = onNavigateToSplitApks,
-                    onCopy = onCopy,
-                )
-            }
-            state.totalSize?.let { size ->
-                InfoRowItem(
-                    label = stringResource(R.string.general_info_total_size),
-                    value = size.formatted(),
-                    rationale = stringResource(R.string.general_info_rationale_total_size),
-                    onShowRationale = { rationaleRow = it },
                     onCopy = onCopy,
                 )
             }
@@ -530,6 +535,7 @@ private fun GeneralInfoLoadingPreview() {
             onBack = {},
             onNavigateToSplitApks = {},
             onNavigateToNativeLibraries = {},
+            onNavigateToStorage = {},
         )
     }
 }
@@ -544,6 +550,7 @@ private fun GeneralInfoErrorPreview() {
             onBack = {},
             onNavigateToSplitApks = {},
             onNavigateToNativeLibraries = {},
+            onNavigateToStorage = {},
         )
     }
 }
@@ -558,11 +565,13 @@ private fun GeneralInfoLoadedPreview() {
             onBack = {},
             onNavigateToSplitApks = {},
             onNavigateToNativeLibraries = {},
+            onNavigateToStorage = {},
         )
     }
 }
 
 private fun sampleGeneralInfoState() = GeneralInfoState.Loaded(
+    analysisMode = AppDetail.AnalysisMode.InstalledPackage,
     applicationName = "Spotify",
     packageName = PackageName("com.spotify.music"),
     processName = "com.spotify.music",

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoState.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoState.kt
@@ -3,6 +3,7 @@ package sk.styk.martin.apkanalyzer.feature.appdetail.impl.generalinfo
 import androidx.compose.runtime.Immutable
 import kotlinx.collections.immutable.ImmutableList
 import sk.styk.martin.apkanalyzer.core.apps.installsource.InstallSourceChain
+import sk.styk.martin.apkanalyzer.core.apps.model.AppDetail
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
@@ -14,6 +15,7 @@ sealed interface GeneralInfoState {
 
     @Immutable
     data class Loaded(
+        val analysisMode: AppDetail.AnalysisMode,
         val applicationName: String,
         val packageName: PackageName,
         val processName: String?,

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/generalinfo/GeneralInfoViewModel.kt
@@ -74,6 +74,7 @@ internal class GeneralInfoViewModel @AssistedInject constructor(
 }
 
 private fun AppDetail.toGeneralInfoState() = GeneralInfoState.Loaded(
+    analysisMode = analysisMode,
     applicationName = info.applicationName,
     packageName = info.packageName,
     processName = info.processName,
@@ -99,7 +100,7 @@ private fun AppDetail.toGeneralInfoState() = GeneralInfoState.Loaded(
     dataDirectory = info.dataDirectory,
     installLocation = info.installLocation.name,
     apkSize = info.apkSize,
-    totalSize = info.totalSize,
+    totalSize = info.storageBreakdown?.total,
     nativeLibraryAbis = nativeLibraries.abis.toImmutableList(),
     nativeLibraryNames = nativeLibraries.libraryNames.toImmutableList(),
     deviceSupportedAbis = Build.SUPPORTED_ABIS.toList().toImmutableList(),

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/navigation/AppDetailEntryProvider.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/navigation/AppDetailEntryProvider.kt
@@ -19,6 +19,7 @@ import sk.styk.martin.apkanalyzer.feature.appdetail.impl.nativelibraries.NativeL
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.permissions.PermissionsScreen
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.requirements.RequirementsScreen
 import sk.styk.martin.apkanalyzer.feature.appdetail.impl.splitapks.SplitApksScreen
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.storage.StorageScreen
 
 fun EntryProviderScope<NavKey>.appDetailEntries(navigator: Navigator) {
     entry<AppDetailNavKey>(
@@ -51,6 +52,16 @@ fun EntryProviderScope<NavKey>.appDetailEntries(navigator: Navigator) {
             onBack = { navigator.goBack() },
             onNavigateToSplitApks = { navigator.navigate(SplitApksNavKey(key.detailInput)) },
             onNavigateToNativeLibraries = { navigator.navigate(NativeLibrariesNavKey(key.detailInput)) },
+            onNavigateToStorage = { navigator.navigate(StorageNavKey(key.detailInput)) },
+        )
+    }
+
+    entry<StorageNavKey>(
+        metadata = slideFromEndEntryMetadata(),
+    ) { key ->
+        StorageScreen(
+            appDetailInput = key.detailInput,
+            onBack = { navigator.goBack() },
         )
     }
 

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/navigation/StorageNavKey.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/navigation/StorageNavKey.kt
@@ -1,0 +1,8 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl.navigation
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
+
+@Serializable
+internal data class StorageNavKey(val detailInput: AppDetailInput) : NavKey

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/storage/StorageAction.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/storage/StorageAction.kt
@@ -1,0 +1,11 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl.storage
+
+internal sealed interface StorageAction {
+    data object Retry : StorageAction
+
+    data object Back : StorageAction
+
+    data object OpenPermissionSettings : StorageAction
+
+    data class CopyValue(val label: String, val value: String) : StorageAction
+}

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/storage/StorageEvent.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/storage/StorageEvent.kt
@@ -1,0 +1,9 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl.storage
+
+internal sealed interface StorageEvent {
+    data object NavigateBack : StorageEvent
+
+    data object ShowCopiedFeedback : StorageEvent
+
+    data object OpenUsagePermissionSettings : StorageEvent
+}

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/storage/StorageScreen.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/storage/StorageScreen.kt
@@ -1,0 +1,272 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl.storage
+
+import android.content.Intent
+import android.provider.Settings
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.persistentListOf
+import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageBreakdown
+import sk.styk.martin.apkanalyzer.core.common.model.AppSize
+import sk.styk.martin.apkanalyzer.core.common.model.megabytes
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.BarChartSegment
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.PermissionRationaleBottomSheet
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.SegmentedBarChart
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Text
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.Toolbar
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
+import sk.styk.martin.apkanalyzer.core.uilibrary.theme.Shapes
+import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.R
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.InfoRow
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.RationaleBottomSheet
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.SectionError
+import sk.styk.martin.apkanalyzer.feature.appdetail.impl.components.SectionLoading
+import kotlin.math.roundToInt
+
+@Composable
+internal fun StorageScreen(
+    appDetailInput: AppDetailInput,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: StorageViewModel = hiltViewModel { factory: StorageViewModel.Factory ->
+        factory.create(appDetailInput)
+    },
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                StorageEvent.NavigateBack -> onBack()
+                StorageEvent.ShowCopiedFeedback -> Toast.makeText(context, R.string.general_info_copied, Toast.LENGTH_SHORT).show()
+                StorageEvent.OpenUsagePermissionSettings -> context.startActivity(Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS))
+            }
+        }
+    }
+
+    StorageContent(
+        state = state,
+        onAction = viewModel::onAction,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun StorageContent(
+    state: StorageState,
+    onAction: (StorageAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(AppTheme.colors.background),
+    ) {
+        Toolbar(
+            title = stringResource(R.string.storage_title),
+            onBack = { onAction(StorageAction.Back) },
+        )
+        when (state) {
+            StorageState.Loading -> SectionLoading()
+
+            StorageState.Error -> SectionError(
+                message = stringResource(R.string.storage_error),
+                onRetry = { onAction(StorageAction.Retry) },
+            )
+
+            StorageState.MissingPermission -> PermissionRationaleBottomSheet(
+                title = stringResource(R.string.storage_permission_title),
+                description = stringResource(R.string.storage_permission_description),
+                openSettingsLabel = stringResource(R.string.storage_permission_open_settings),
+                onOpenSettings = { onAction(StorageAction.OpenPermissionSettings) },
+                onDismiss = { onAction(StorageAction.Back) },
+            )
+
+            is StorageState.Loaded -> StorageLoadedContent(breakdown = state.breakdown, onAction = onAction)
+        }
+    }
+}
+
+@Composable
+private fun StorageLoadedContent(
+    breakdown: StorageBreakdown,
+    onAction: (StorageAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var rationaleRow by remember { mutableStateOf<InfoRow?>(null) }
+    val appLabel = stringResource(R.string.storage_legend_app)
+    val dataLabel = stringResource(R.string.storage_legend_data)
+    val cacheLabel = stringResource(R.string.storage_legend_cache)
+    val appRationale = stringResource(R.string.storage_rationale_app)
+    val dataRationale = stringResource(R.string.storage_rationale_data)
+    val cacheRationale = stringResource(R.string.storage_rationale_cache)
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+    ) {
+        Text(
+            text = breakdown.total.formatted(),
+            style = AppTheme.typography.headlineSmall,
+            color = AppTheme.colors.onBackground,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = stringResource(R.string.storage_explanation),
+            style = AppTheme.typography.bodySmall,
+            color = AppTheme.colors.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+        SegmentedBarChart(
+            segments = persistentListOf(
+                BarChartSegment(value = breakdown.appBytes.bytes.toFloat(), color = AppTheme.colors.primary),
+                BarChartSegment(value = breakdown.dataBytes.bytes.toFloat(), color = AppTheme.colors.secondary),
+                BarChartSegment(value = breakdown.cacheBytes.bytes.toFloat(), color = AppTheme.colors.tertiary),
+            ),
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+        StorageLegendRow(
+            color = AppTheme.colors.primary,
+            label = appLabel,
+            size = breakdown.appBytes,
+            total = breakdown.total,
+            onShowRationale = { rationaleRow = InfoRow(appLabel, breakdown.appBytes.formatted(), appRationale) },
+            onCopy = { label, value -> onAction(StorageAction.CopyValue(label, value)) },
+        )
+        StorageLegendRow(
+            color = AppTheme.colors.secondary,
+            label = dataLabel,
+            size = breakdown.dataBytes,
+            total = breakdown.total,
+            onShowRationale = { rationaleRow = InfoRow(dataLabel, breakdown.dataBytes.formatted(), dataRationale) },
+            onCopy = { label, value -> onAction(StorageAction.CopyValue(label, value)) },
+        )
+        StorageLegendRow(
+            color = AppTheme.colors.tertiary,
+            label = cacheLabel,
+            size = breakdown.cacheBytes,
+            total = breakdown.total,
+            onShowRationale = { rationaleRow = InfoRow(cacheLabel, breakdown.cacheBytes.formatted(), cacheRationale) },
+            onCopy = { label, value -> onAction(StorageAction.CopyValue(label, value)) },
+        )
+    }
+
+    rationaleRow?.let { row ->
+        RationaleBottomSheet(row = row, onDismiss = { rationaleRow = null })
+    }
+}
+
+@Composable
+private fun StorageLegendRow(
+    color: Color,
+    label: String,
+    size: AppSize,
+    total: AppSize,
+    onShowRationale: () -> Unit,
+    onCopy: (label: String, value: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val percent = if (total.bytes > 0) (size.bytes.toFloat() / total.bytes.toFloat() * 100).roundToInt() else 0
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(Shapes.CardShape)
+            .combinedClickable(
+                onClick = onShowRationale,
+                onLongClick = { onCopy(label, size.formatted()) },
+            )
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(CircleShape)
+                .background(color),
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = label,
+            style = AppTheme.typography.titleSmall,
+            color = AppTheme.colors.onBackground,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = stringResource(R.string.storage_legend_value, size.formatted(), percent),
+            style = AppTheme.typography.bodyMedium,
+            color = AppTheme.colors.onSurfaceVariant,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun StorageLoadingPreview() {
+    ApkAnalyzerTheme {
+        StorageContent(state = StorageState.Loading, onAction = {})
+    }
+}
+
+@Preview
+@Composable
+private fun StorageErrorPreview() {
+    ApkAnalyzerTheme {
+        StorageContent(state = StorageState.Error, onAction = {})
+    }
+}
+
+@Preview
+@Composable
+private fun StorageMissingPermissionPreview() {
+    ApkAnalyzerTheme {
+        StorageContent(state = StorageState.MissingPermission, onAction = {})
+    }
+}
+
+@Preview
+@Composable
+private fun StorageLoadedPreview() {
+    ApkAnalyzerTheme {
+        StorageContent(
+            state = StorageState.Loaded(
+                breakdown = StorageBreakdown(
+                    appBytes = 620.megabytes,
+                    dataBytes = 240.megabytes,
+                    cacheBytes = 90.megabytes,
+                ),
+            ),
+            onAction = {},
+        )
+    }
+}

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/storage/StorageState.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/storage/StorageState.kt
@@ -1,0 +1,16 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl.storage
+
+import androidx.compose.runtime.Immutable
+import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageBreakdown
+
+@Immutable
+internal sealed interface StorageState {
+    data object Loading : StorageState
+
+    data object Error : StorageState
+
+    data object MissingPermission : StorageState
+
+    @Immutable
+    data class Loaded(val breakdown: StorageBreakdown) : StorageState
+}

--- a/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/storage/StorageViewModel.kt
+++ b/feature/app-detail/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/appdetail/impl/storage/StorageViewModel.kt
@@ -1,0 +1,105 @@
+package sk.styk.martin.apkanalyzer.feature.appdetail.impl.storage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageBreakdown
+import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageStatsRepository
+import sk.styk.martin.apkanalyzer.core.common.clipboard.ClipboardManager
+import sk.styk.martin.apkanalyzer.core.common.clipboard.CopyResult
+import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.feature.appdetail.api.AppDetailInput
+
+private const val STOP_TIMEOUT_MS = 5000L
+
+@HiltViewModel(assistedFactory = StorageViewModel.Factory::class)
+internal class StorageViewModel @AssistedInject constructor(
+    @Assisted appDetailInput: AppDetailInput,
+    private val storageStatsRepository: StorageStatsRepository,
+    private val dispatcherProvider: DispatcherProvider,
+    private val clipboardManager: ClipboardManager,
+) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(appDetailInput: AppDetailInput): StorageViewModel
+    }
+
+    private val packageName = (appDetailInput as? AppDetailInput.InstalledPackage)?.let { PackageName(it.packageName) }
+    private val isLoading = MutableStateFlow(true)
+    private val breakdown = MutableStateFlow<StorageBreakdown?>(null)
+
+    val state: StateFlow<StorageState> = combine(
+        isLoading,
+        breakdown,
+        storageStatsRepository.isPermissionGranted,
+    ) { loading, breakdown, permissionGranted ->
+        when {
+            loading -> StorageState.Loading
+            !permissionGranted -> StorageState.MissingPermission
+            breakdown != null -> StorageState.Loaded(breakdown)
+            else -> StorageState.Error
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), StorageState.Loading)
+
+    private val eventChannel = Channel<StorageEvent>(Channel.BUFFERED)
+    val events = eventChannel.receiveAsFlow()
+
+    init {
+        loadBreakdown()
+        storageStatsRepository.isPermissionGranted
+            .drop(1)
+            .filter { it }
+            .onEach { loadBreakdown() }
+            .launchIn(viewModelScope)
+    }
+
+    fun onAction(action: StorageAction) {
+        when (action) {
+            StorageAction.Retry -> loadBreakdown()
+
+            StorageAction.Back -> eventChannel.trySend(StorageEvent.NavigateBack)
+
+            StorageAction.OpenPermissionSettings -> eventChannel.trySend(StorageEvent.OpenUsagePermissionSettings)
+
+            is StorageAction.CopyValue -> {
+                if (clipboardManager.copy(action.label, action.value) == CopyResult.FeedbackNotShown) {
+                    viewModelScope.launch { eventChannel.send(StorageEvent.ShowCopiedFeedback) }
+                }
+            }
+        }
+    }
+
+    private fun loadBreakdown() {
+        val name = packageName
+        if (name == null) {
+            isLoading.value = false
+            breakdown.value = null
+            return
+        }
+        isLoading.value = true
+        viewModelScope.launch {
+            breakdown.value = withContext(dispatcherProvider.io()) {
+                storageStatsRepository.queryBreakdown(name)
+            }
+            isLoading.value = false
+        }
+    }
+}

--- a/feature/app-detail/impl/src/main/res/values/strings.xml
+++ b/feature/app-detail/impl/src/main/res/values/strings.xml
@@ -307,7 +307,8 @@
         <item quantity="one">Installed as %1$d split APK</item>
         <item quantity="other">Installed as %1$d split APKs</item>
     </plurals>
-    <string name="general_info_total_size">Total Size</string>
+    <string name="general_info_storage">Storage</string>
+    <string name="general_info_storage_permission_needed">Usage access needed</string>
     <string name="general_info_native_library_abis">CPU architectures</string>
     <string name="general_info_native_library_abis_none">No native code</string>
     <string name="general_info_native_library_files">Native library files</string>
@@ -356,7 +357,6 @@
     <string name="general_info_rationale_data_directory">The file system path where the app stores its private data, databases, and shared preferences.</string>
     <string name="general_info_rationale_install_location">The preferred storage location declared by the developer — internal storage, external storage, or automatic.</string>
     <string name="general_info_rationale_apk_size">The combined size of the installed APK files on disk, excluding app data, caches, and runtime-generated files. Most apps installed from Google Play are split into a base APK plus additional APKs for your device\'s language and screen density; this total covers all of them.</string>
-    <string name="general_info_rationale_total_size">The combined size of the APK, app data, and cached files. Requires usage access permission.</string>
     <string name="general_info_rationale_native_library_abis">The processor types this app includes compiled native code for, read from the APK\'s own files rather than what this device reports.</string>
     <string name="general_info_native_library_device_support">This device supports: %1$s.</string>
     <string name="general_info_native_library_incompatible">None of those processor types match what this device supports, so this app\'s native code likely won\'t run here.</string>
@@ -793,4 +793,18 @@
     <string name="nativelibraries_detail_total_size">Total size</string>
     <string name="nativelibraries_detail_section_variants">Per processor type</string>
     <string name="nativelibraries_detail_variant_source">Bundled in %1$s</string>
+
+    <string name="storage_title">Storage</string>
+    <string name="storage_explanation">How this app\'s total size on this device splits between the installed package, saved data, and cache.</string>
+    <string name="storage_error">Failed to load storage details</string>
+    <string name="storage_legend_app">App</string>
+    <string name="storage_legend_data">Data</string>
+    <string name="storage_legend_cache">Cache</string>
+    <string name="storage_legend_value">%1$s · %2$d%%</string>
+    <string name="storage_rationale_app">The size of the installed APK files on disk — the app itself, before it stores any data.</string>
+    <string name="storage_rationale_data">Files, databases, and settings the app has saved while running, such as downloads, drafts, and accounts.</string>
+    <string name="storage_rationale_cache">Temporary files the app can regenerate on demand, such as downloaded images. Android may clear this automatically when storage runs low.</string>
+    <string name="storage_permission_title">Allow usage access</string>
+    <string name="storage_permission_description">This breakdown measures the app\'s full footprint — installer, stored data, and cache combined. Grant usage access in Settings to see it.</string>
+    <string name="storage_permission_open_settings">Open settings</string>
 </resources>

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/components/quickfilter/QuickFilterRow.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/components/quickfilter/QuickFilterRow.kt
@@ -19,13 +19,13 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.persistentSetOf
+import sk.styk.martin.apkanalyzer.core.common.model.AppDataPermission
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.Chip
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.PermissionRationaleBottomSheet
 import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
 import sk.styk.martin.apkanalyzer.core.uilibrary.modifier.sharedElement
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
 import sk.styk.martin.apkanalyzer.feature.apps.impl.R
-import sk.styk.martin.apkanalyzer.feature.apps.impl.components.AppDataPermission
-import sk.styk.martin.apkanalyzer.feature.apps.impl.components.PermissionRationaleBottomSheet
 import sk.styk.martin.apkanalyzer.feature.apps.impl.filter.domain.QuickFilter
 
 @Composable

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/components/quickfilter/QuickFilterRowAction.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/components/quickfilter/QuickFilterRowAction.kt
@@ -1,6 +1,6 @@
 package sk.styk.martin.apkanalyzer.feature.apps.impl.components.quickfilter
 
-import sk.styk.martin.apkanalyzer.feature.apps.impl.components.AppDataPermission
+import sk.styk.martin.apkanalyzer.core.common.model.AppDataPermission
 import sk.styk.martin.apkanalyzer.feature.apps.impl.filter.domain.QuickFilter
 
 sealed interface QuickFilterRowAction {

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/components/quickfilter/QuickFilterRowState.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/components/quickfilter/QuickFilterRowState.kt
@@ -3,7 +3,7 @@ package sk.styk.martin.apkanalyzer.feature.apps.impl.components.quickfilter
 import androidx.compose.runtime.Immutable
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
-import sk.styk.martin.apkanalyzer.feature.apps.impl.components.AppDataPermission
+import sk.styk.martin.apkanalyzer.core.common.model.AppDataPermission
 import sk.styk.martin.apkanalyzer.feature.apps.impl.filter.domain.QuickFilter
 
 @Immutable

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/components/quickfilter/QuickFilterRowViewModel.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/components/quickfilter/QuickFilterRowViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageStatsRepository
 import sk.styk.martin.apkanalyzer.core.apps.usagestats.UsageStatsRepository
-import sk.styk.martin.apkanalyzer.feature.apps.impl.components.AppDataPermission
+import sk.styk.martin.apkanalyzer.core.common.model.AppDataPermission
 import sk.styk.martin.apkanalyzer.feature.apps.impl.filter.domain.AppFilterRepository
 import sk.styk.martin.apkanalyzer.feature.apps.impl.filter.domain.QuickFilter
 import javax.inject.Inject

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsAction.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsAction.kt
@@ -1,7 +1,7 @@
 package sk.styk.martin.apkanalyzer.feature.apps.impl.list
 
+import sk.styk.martin.apkanalyzer.core.common.model.AppDataPermission
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
-import sk.styk.martin.apkanalyzer.feature.apps.impl.components.AppDataPermission
 
 sealed interface AppsAction {
     data class SortTypeSelected(val sortType: SortType) : AppsAction

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsScreen.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsScreen.kt
@@ -40,6 +40,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import sk.styk.martin.apkanalyzer.core.common.model.AppDataPermission
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
@@ -51,6 +52,7 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.components.Icon
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.IconButton
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.IconButtonStyle
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.InactiveSearchBar
+import sk.styk.martin.apkanalyzer.core.uilibrary.components.PermissionRationaleBottomSheet
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.Text
 import sk.styk.martin.apkanalyzer.core.uilibrary.components.navigationBarContentPadding
 import sk.styk.martin.apkanalyzer.core.uilibrary.icons.ApkAnalyzerIcons
@@ -64,9 +66,7 @@ import sk.styk.martin.apkanalyzer.core.uilibrary.theme.ApkAnalyzerTheme
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.AppTheme
 import sk.styk.martin.apkanalyzer.core.uilibrary.theme.Shapes
 import sk.styk.martin.apkanalyzer.feature.apps.impl.R
-import sk.styk.martin.apkanalyzer.feature.apps.impl.components.AppDataPermission
 import sk.styk.martin.apkanalyzer.feature.apps.impl.components.AppListItemRowSkeleton
-import sk.styk.martin.apkanalyzer.feature.apps.impl.components.PermissionRationaleBottomSheet
 import sk.styk.martin.apkanalyzer.feature.apps.impl.components.RecentAppsRowSkeleton
 import sk.styk.martin.apkanalyzer.feature.apps.impl.components.apkfilepicker.ApkFilePickerButton
 import sk.styk.martin.apkanalyzer.feature.apps.impl.components.appitem.AppListItemRow

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsState.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsState.kt
@@ -2,10 +2,10 @@ package sk.styk.martin.apkanalyzer.feature.apps.impl.list
 
 import androidx.compose.runtime.Immutable
 import kotlinx.collections.immutable.ImmutableList
+import sk.styk.martin.apkanalyzer.core.common.model.AppDataPermission
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.AppSource
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
-import sk.styk.martin.apkanalyzer.feature.apps.impl.components.AppDataPermission
 import sk.styk.martin.apkanalyzer.feature.apps.impl.filter.domain.AppFilterState
 import java.time.Instant
 

--- a/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsViewModel.kt
+++ b/feature/apps/impl/src/main/kotlin/sk/styk/martin/apkanalyzer/feature/apps/impl/list/AppsViewModel.kt
@@ -18,8 +18,8 @@ import sk.styk.martin.apkanalyzer.core.apps.model.InstalledApp
 import sk.styk.martin.apkanalyzer.core.apps.storagestats.StorageStatsRepository
 import sk.styk.martin.apkanalyzer.core.apps.usagestats.UsageStatsRepository
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.model.AppDataPermission
 import sk.styk.martin.apkanalyzer.core.userpreferences.RecentlyViewedAppsRepository
-import sk.styk.martin.apkanalyzer.feature.apps.impl.components.AppDataPermission
 import sk.styk.martin.apkanalyzer.feature.apps.impl.filter.domain.AppFilterRepository
 import sk.styk.martin.apkanalyzer.feature.apps.impl.filter.domain.FilterAppsUseCase
 import java.text.Collator


### PR DESCRIPTION
## Summary
- Adds `StorageBreakdown` (app/data/cache) to the data StorageStats already provides, replacing the summed-only `AppSize` total that used to be all `AppInfo` carried.
- New Storage screen off General Info (right after APK Size), with an animated stacked-bar chart (`SegmentedBarChart` in `core:ui-library`) and a legend of App/Data/Cache with rationale-on-tap, copy-on-long-press.
- The General Info row is always visible (renamed "Storage") instead of disappearing when usage-access isn't granted, and the Storage screen shows a proper permission prompt with a settings deep link — self-healing back to real data once granted, no restart needed.
- `AppDataPermission` and `PermissionRationaleBottomSheet` moved from `feature:apps` into `core:common`/`core:ui-library` since app-detail is now a second consumer and can't depend on another feature's `impl`.
- Fixed a stale-cache bug found during device testing: `AppDetailRepositoryImpl` was baking a transient storage-query failure into the long-lived cached `AppDetail`, so General Info could show "permission needed" long after the Storage screen (which always queries fresh) had real data. Storage breakdown is now always re-queried live, even on a cache hit.
- Moved `FR-37` and the already-shipped-but-stale `FR-27` (component launching) from `roadmap.md` to `shipped.md`.

## Test plan
- [x] `spotlessApply`, and `compileDebugKotlin` for every touched module
- [x] Verified on a physical device (OnePlus 8T): General Info → Storage navigation, chart renders and animates correctly including a real 1%-share segment, legend tap/long-press, dark/light row order
- [x] Revoked and re-granted usage access via Settings on-device — confirmed the General Info row and Storage screen both recover without an app restart