### PR TITLE
OBS-04/OBS-05: Instrument app detail, manifest, signing-index, and app-index loading performance

### DIFF
--- a/core/ai-insights/src/main/kotlin/sk/styk/martin/apkanalyzer/core/aiinsights/appdescription/AppAiDescriptionRepositoryImpl.kt
+++ b/core/ai-insights/src/main/kotlin/sk/styk/martin/apkanalyzer/core/aiinsights/appdescription/AppAiDescriptionRepositoryImpl.kt
@@ -20,6 +20,8 @@ import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTrace
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.analysisMode
+import sk.styk.martin.apkanalyzer.core.common.performance.analysisModeAttribute
 import sk.styk.martin.apkanalyzer.core.common.performance.outcome
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import javax.inject.Inject
@@ -83,7 +85,7 @@ internal class AppAiDescriptionRepositoryImpl @Inject constructor(
     }
 
     private suspend fun loadDescription(reference: AppReference): AppAiDescription? = performanceTracker.startCancellableTrace("ai_summary_load") {
-        this["analysis_mode"] = reference.toString()
+        analysisMode = reference.analysisModeAttribute
         Logger.d(TAG, "AI description loading started: reference=$reference")
         runCatchingCancellable {
             val context = fetchContext(reference) ?: return@runCatchingCancellable null

--- a/core/app-index/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appindex/AppIndexRepositoryImpl.kt
+++ b/core/app-index/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appindex/AppIndexRepositoryImpl.kt
@@ -18,6 +18,7 @@ import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.appCount
 import sk.styk.martin.apkanalyzer.core.common.performance.outcome
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import sk.styk.martin.apkanalyzer.core.common.performance.timedSection
@@ -44,9 +45,9 @@ internal class AppIndexRepositoryImpl @Inject constructor(
     override fun index(): Flow<AppIndexStatus> = cachedIndex
 
     private suspend fun buildIndex(apps: List<InstalledApp>, signing: Map<PackageName, AppSigning>) =
-        performanceTracker.startCancellableTrace("app_index_build") { trace ->
-            trace["app_count"] = apps.size
-            trace.timedSection(tag = TAG, operation = "App index build", metric = "index_build_ms") {
+        performanceTracker.startCancellableTrace("app_index_build") {
+            appCount = apps.size
+            timedSection(tag = TAG, operation = "App index build", metric = "index_build_ms") {
                 AppAttributeIndex(
                     targetSdk = apps.byTargetSdk(),
                     minSdk = apps.byMinSdk(),
@@ -60,7 +61,7 @@ internal class AppIndexRepositoryImpl @Inject constructor(
                     sharedUserId = apps.bySharedUserId(),
                     appCategory = apps.byAppCategory(),
                 )
-            }.also { trace.outcome = TraceOutcome.Success }
+            }.also { outcome = TraceOutcome.Success }
         }
 
     private fun List<InstalledApp>.byTargetSdk() = groupBy(InstalledApp::targetSdk, InstalledApp::packageName)

--- a/core/app-index/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appindex/AppIndexRepositoryImpl.kt
+++ b/core/app-index/src/main/kotlin/sk/styk/martin/apkanalyzer/core/appindex/AppIndexRepositoryImpl.kt
@@ -16,13 +16,21 @@ import sk.styk.martin.apkanalyzer.core.apps.signing.AppSigningRepository
 import sk.styk.martin.apkanalyzer.core.apps.signing.Certificate
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.outcome
+import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
+import sk.styk.martin.apkanalyzer.core.common.performance.timedSection
 import javax.inject.Inject
+
+private const val TAG = "AppIndexRepositoryImpl"
 
 internal class AppIndexRepositoryImpl @Inject constructor(
     installedAppsRepository: InstalledAppsRepository,
     appSigningRepository: AppSigningRepository,
     dispatcherProvider: DispatcherProvider,
     appScope: CoroutineScope,
+    private val performanceTracker: PerformanceTracker,
 ) : AppIndexRepository {
 
     private val cachedIndex = combine(
@@ -35,19 +43,25 @@ internal class AppIndexRepositoryImpl @Inject constructor(
 
     override fun index(): Flow<AppIndexStatus> = cachedIndex
 
-    private fun buildIndex(apps: List<InstalledApp>, signing: Map<PackageName, AppSigning>) = AppAttributeIndex(
-        targetSdk = apps.byTargetSdk(),
-        minSdk = apps.byMinSdk(),
-        installSource = apps.byInstallSource(),
-        permission = apps.byPermission(),
-        certificateSha256 = apps.byCertificate(signing) { it.certificateHashSha256 },
-        certificateSha1 = apps.byCertificate(signing) { it.certificateHashSha1 },
-        certificateMd5 = apps.byCertificate(signing) { it.certificateHashMd5 },
-        certificateOrganization = apps.byCertificate(signing) { it.subject.organization },
-        certificateCountry = apps.byCertificate(signing) { it.subject.country },
-        sharedUserId = apps.bySharedUserId(),
-        appCategory = apps.byAppCategory(),
-    )
+    private suspend fun buildIndex(apps: List<InstalledApp>, signing: Map<PackageName, AppSigning>) =
+        performanceTracker.startCancellableTrace("app_index_build") { trace ->
+            trace["app_count"] = apps.size
+            trace.timedSection(tag = TAG, operation = "App index build", metric = "index_build_ms") {
+                AppAttributeIndex(
+                    targetSdk = apps.byTargetSdk(),
+                    minSdk = apps.byMinSdk(),
+                    installSource = apps.byInstallSource(),
+                    permission = apps.byPermission(),
+                    certificateSha256 = apps.byCertificate(signing) { it.certificateHashSha256 },
+                    certificateSha1 = apps.byCertificate(signing) { it.certificateHashSha1 },
+                    certificateMd5 = apps.byCertificate(signing) { it.certificateHashMd5 },
+                    certificateOrganization = apps.byCertificate(signing) { it.subject.organization },
+                    certificateCountry = apps.byCertificate(signing) { it.subject.country },
+                    sharedUserId = apps.bySharedUserId(),
+                    appCategory = apps.byAppCategory(),
+                )
+            }.also { trace.outcome = TraceOutcome.Success }
+        }
 
     private fun List<InstalledApp>.byTargetSdk() = groupBy(InstalledApp::targetSdk, InstalledApp::packageName)
 

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -54,6 +54,15 @@ Attach a throwable only for unexpected recoverable degradation or terminal failu
 layer that owns that outcome. Let coroutine cancellation propagate without logging it. Package names
 and APK file paths are valid diagnostic context.
 
+`AppDetailRepositoryImpl` owns one `app_detail_load` trace around the complete public request,
+including cache hits. Record only bounded analysis mode, cache result, availability, and terminal
+outcome attributes; package names and APK paths remain local log context. The parent trace already
+measures total duration, so add a custom stage metric only for a concrete production question.
+
+Use `startCancellableTrace` for trace lifetime and cancellation outcome. Classify cached and uncached
+results from facts persisted in `AppDetail`; nullable storage, usage, certificate, and packaging data
+must not be promoted into guessed telemetry outcomes.
+
 ## Signing Semantics
 
 * `apkContentsSigners` is the current signer set. Multiple current signers form one package identity

--- a/core/apps/AGENTS.md
+++ b/core/apps/AGENTS.md
@@ -47,17 +47,29 @@ block.
 ## Loading Observability
 
 Use direct, readable messages in the form `<operation> loading <started|finished|degraded|failed>`
-with useful result counts or context. DEBUG marks starts and successful internal stages, INFO marks
-successful public-load completion, WARN marks degraded results, and ERROR marks terminal failures.
+with useful result counts or context. INFO marks successful public-load completion, WARN marks
+degraded results, and ERROR marks terminal failures.
+
+DEBUG marks the start and finish of an internal stage only when that stage is itself expensive — a
+platform/IPC query, a file or manifest read, a loop that calls into the platform once per item. A
+pure in-memory mapping over data already fetched does not earn a DEBUG pair. Use
+`PerformanceTrace.timedSection` (`core:common`) for every such stage instead of logging and setting a
+trace metric by hand: it logs the started/finished pair and records the duration as a `<metric>`
+trace attribute in one call. `AppDetailRepositoryImpl.timedStage` is a thin wrapper around it for that
+file's `"App detail <stage> loading"` wording; repositories with only one or two timed stages
+(`InstalledAppsRepositoryImpl`, `StorageStatsRepositoryImpl`, `UsageStatsRepositoryImpl`) call
+`timedSection` directly. If a stage can also degrade to a fallback, add a WARN for that outcome on
+top of the timing — don't stack a WARN onto every stage, only the ones that actually can degrade.
 
 Attach a throwable only for unexpected recoverable degradation or terminal failure, and only at the
 layer that owns that outcome. Let coroutine cancellation propagate without logging it. Package names
 and APK file paths are valid diagnostic context.
 
 `AppDetailRepositoryImpl` owns one `app_detail_load` trace around the complete public request,
-including cache hits. Record only bounded analysis mode, cache result, availability, and terminal
-outcome attributes; package names and APK paths remain local log context. The parent trace already
-measures total duration, so add a custom stage metric only for a concrete production question.
+including cache hits. Every internal stage (package query, manifest parsing, certificates, signing
+schemes, permissions, ...) records its own `<stage>_ms` metric via `timedStage`, alongside the bounded
+analysis mode, cache result, availability, and terminal outcome attributes; package names and APK
+paths remain local log context, not trace attributes.
 
 Use `startCancellableTrace` for trace lifetime and cancellation outcome. Classify cached and uncached
 results from facts persisted in `AppDetail`; nullable storage, usage, certificate, and packaging data

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -48,6 +48,10 @@ import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.AppSize
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTrace
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import java.io.File
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
@@ -68,6 +72,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
     packageChangesObserver: PackageChangesObserver,
     appScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    private val performanceTracker: PerformanceTracker,
 ) : AppDetailRepository {
 
     private val cache = ConcurrentHashMap<CacheKey, AppDetail>()
@@ -89,22 +94,39 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             .launchIn(appScope + dispatcherProvider.default())
     }
 
-    override suspend fun details(reference: AppReference): Result<AppDetail> = when (reference) {
-        is AppReference.InstalledPackage -> installedPackageDetails(reference.packageName)
-        is AppReference.ApkFile -> apkFilePackageDetails(File(reference.path))
+    override suspend fun details(reference: AppReference): Result<AppDetail> = runCatchingCancellable {
+        performanceTracker.startCancellableTrace(APP_DETAIL_LOAD_TRACE) { trace ->
+            trace[ANALYSIS_MODE_ATTRIBUTE] = reference.analysisModeAttribute
+            val result = when (reference) {
+                is AppReference.InstalledPackage -> installedPackageDetails(reference.packageName, trace)
+                is AppReference.ApkFile -> apkFilePackageDetails(File(reference.path), trace)
+            }
+            result.fold(
+                onSuccess = { detail ->
+                    trace.recordResult(detail)
+                    detail
+                },
+                onFailure = { failure ->
+                    trace.recordErrorPreserving(failure)
+                    throw failure
+                },
+            )
+        }
     }
 
-    private suspend fun installedPackageDetails(packageName: PackageName): Result<AppDetail> {
+    private suspend fun installedPackageDetails(packageName: PackageName, trace: PerformanceTrace): Result<AppDetail> {
         val context = "mode=installed package=${packageName.value}"
         val cacheKey = CacheKey.InstalledPackage(packageName)
         Logger.d(TAG, "App detail loading started: $context")
         Logger.d(TAG, "App detail cache lookup started: $context")
-        cache[cacheKey]?.let {
+        val cachedDetail = cache[cacheKey]
+        trace[CACHE_HIT_ATTRIBUTE] = cachedDetail?.let { ATTRIBUTE_TRUE } ?: ATTRIBUTE_FALSE
+        cachedDetail?.let {
             Logger.d(TAG, "App detail cache lookup finished: cache hit, $context")
-            if (it.areComponentIntentFiltersAvailable) {
+            if (!it.isPerformanceDegraded) {
                 Logger.i(TAG, "App detail loading finished: cache hit, $context")
             } else {
-                Logger.w(TAG, "App detail loading degraded: component intent filters unavailable, cache hit, $context")
+                Logger.w(TAG, "App detail loading degraded: optional analysis unavailable, cache hit, $context")
             }
             return Result.success(it)
         }
@@ -148,27 +170,29 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             )
         }.onSuccess { detail ->
             cache[cacheKey] = detail
-            if (detail.areComponentIntentFiltersAvailable) {
+            if (!detail.isPerformanceDegraded) {
                 Logger.i(TAG, "App detail loading finished: $context")
             } else {
-                Logger.w(TAG, "App detail loading degraded: component intent filters unavailable, $context")
+                Logger.w(TAG, "App detail loading degraded: optional analysis unavailable, $context")
             }
         }.onFailure {
             Logger.e(TAG, it, "App detail loading failed: $context")
         }
     }
 
-    private suspend fun apkFilePackageDetails(accessibleFile: File): Result<AppDetail> {
+    private suspend fun apkFilePackageDetails(accessibleFile: File, trace: PerformanceTrace): Result<AppDetail> {
         val context = "mode=apk_file apk_path=${accessibleFile.absolutePath}"
         val cacheKey = CacheKey.ApkFile(accessibleFile.absolutePath, accessibleFile.lastModified())
         Logger.d(TAG, "App detail loading started: $context")
         Logger.d(TAG, "App detail cache lookup started: $context")
-        cache[cacheKey]?.let {
+        val cachedDetail = cache[cacheKey]
+        trace[CACHE_HIT_ATTRIBUTE] = cachedDetail?.let { ATTRIBUTE_TRUE } ?: ATTRIBUTE_FALSE
+        cachedDetail?.let {
             Logger.d(TAG, "App detail cache lookup finished: cache hit, $context")
-            if (it.areComponentIntentFiltersAvailable) {
+            if (!it.isPerformanceDegraded) {
                 Logger.i(TAG, "App detail loading finished: cache hit, $context")
             } else {
-                Logger.w(TAG, "App detail loading degraded: component intent filters unavailable, cache hit, $context")
+                Logger.w(TAG, "App detail loading degraded: optional analysis unavailable, cache hit, $context")
             }
             return Result.success(it)
         }
@@ -198,10 +222,10 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             )
         }.onSuccess { detail ->
             cache[cacheKey] = detail
-            if (detail.areComponentIntentFiltersAvailable) {
+            if (!detail.isPerformanceDegraded) {
                 Logger.i(TAG, "App detail loading finished: $context")
             } else {
-                Logger.w(TAG, "App detail loading degraded: component intent filters unavailable, $context")
+                Logger.w(TAG, "App detail loading degraded: optional analysis unavailable, $context")
             }
         }.onFailure {
             Logger.e(TAG, it, "App detail loading failed: $context")
@@ -465,3 +489,39 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         private val launcherCategories = listOf(Intent.CATEGORY_LAUNCHER, Intent.CATEGORY_LEANBACK_LAUNCHER)
     }
 }
+
+private val AppReference.analysisModeAttribute: String
+    get() = when (this) {
+        is AppReference.InstalledPackage -> ANALYSIS_MODE_INSTALLED
+        is AppReference.ApkFile -> ANALYSIS_MODE_APK_FILE
+    }
+
+private val AppDetail.isPerformanceDegraded: Boolean
+    get() = !areComponentIntentFiltersAvailable || signing.signingSchemeVersions == null
+
+private fun PerformanceTrace.recordResult(detail: AppDetail) {
+    this[INTENT_FILTERS_ATTRIBUTE] = if (detail.areComponentIntentFiltersAvailable) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE
+    this[SIGNING_SCHEMES_ATTRIBUTE] = if (detail.signing.signingSchemeVersions != null) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE
+    setOutcome(if (detail.isPerformanceDegraded) TraceOutcome.Degraded else TraceOutcome.Success)
+}
+
+private fun PerformanceTrace.recordErrorPreserving(failure: Throwable) {
+    val telemetryFailure = runCatching {
+        setOutcome(TraceOutcome.Error)
+    }.exceptionOrNull()
+    if (telemetryFailure != null && telemetryFailure !== failure) {
+        failure.addSuppressed(telemetryFailure)
+    }
+}
+
+private const val APP_DETAIL_LOAD_TRACE = "app_detail_load"
+private const val ANALYSIS_MODE_ATTRIBUTE = "analysis_mode"
+private const val CACHE_HIT_ATTRIBUTE = "cache_hit"
+private const val INTENT_FILTERS_ATTRIBUTE = "intent_filters"
+private const val SIGNING_SCHEMES_ATTRIBUTE = "signing_schemes"
+private const val ANALYSIS_MODE_INSTALLED = "installed"
+private const val ANALYSIS_MODE_APK_FILE = "apk_file"
+private const val ATTRIBUTE_TRUE = "true"
+private const val ATTRIBUTE_FALSE = "false"
+private const val AVAILABILITY_AVAILABLE = "available"
+private const val AVAILABILITY_UNAVAILABLE = "unavailable"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -51,12 +51,16 @@ import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTrace
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.outcome
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
+import sk.styk.martin.apkanalyzer.core.common.performance.timedSection
 import java.io.File
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private const val TAG = "AppDetailRepositoryImpl"
 
 @Suppress("TooManyFunctions")
 @Singleton
@@ -94,72 +98,45 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             .launchIn(appScope + dispatcherProvider.default())
     }
 
-    override suspend fun details(reference: AppReference): Result<AppDetail> = runCatchingCancellable {
-        performanceTracker.startCancellableTrace(APP_DETAIL_LOAD_TRACE) { trace ->
-            trace[ANALYSIS_MODE_ATTRIBUTE] = reference.analysisModeAttribute
-            val result = when (reference) {
-                is AppReference.InstalledPackage -> installedPackageDetails(reference.packageName, trace)
-                is AppReference.ApkFile -> apkFilePackageDetails(File(reference.path), trace)
-            }
-            result.fold(
-                onSuccess = { detail ->
-                    trace.recordResult(detail)
-                    detail
-                },
-                onFailure = { failure ->
-                    trace.recordErrorPreserving(failure)
-                    throw failure
-                },
-            )
+    override suspend fun details(reference: AppReference): Result<AppDetail> = performanceTracker.startCancellableTrace("app_detail_load") { trace ->
+        trace["analysis_mode"] = reference.analysisModeAttribute
+        when (reference) {
+            is AppReference.InstalledPackage -> installedPackageDetails(reference.packageName, trace)
+            is AppReference.ApkFile -> apkFilePackageDetails(File(reference.path), trace)
+        }.onSuccess {
+            trace.recordResult(it)
+        }.onFailure {
+            trace.recordErrorPreserving(it)
         }
     }
 
     private suspend fun installedPackageDetails(packageName: PackageName, trace: PerformanceTrace): Result<AppDetail> {
         val context = "mode=installed package=${packageName.value}"
         val cacheKey = CacheKey.InstalledPackage(packageName)
-        Logger.d(TAG, "App detail loading started: $context")
-        Logger.d(TAG, "App detail cache lookup started: $context")
+        Logger.i(TAG, "App detail loading started: $context")
         val cachedDetail = cache[cacheKey]
-        trace[CACHE_HIT_ATTRIBUTE] = cachedDetail?.let { ATTRIBUTE_TRUE } ?: ATTRIBUTE_FALSE
         cachedDetail?.let {
-            Logger.d(TAG, "App detail cache lookup finished: cache hit, $context")
-            if (!it.isPerformanceDegraded) {
-                Logger.i(TAG, "App detail loading finished: cache hit, $context")
-            } else {
-                Logger.w(TAG, "App detail loading degraded: optional analysis unavailable, cache hit, $context")
-            }
+            trace[CACHE_HIT_ATTRIBUTE] = true.toString()
+            Logger.i(TAG, "App detail loading finished: cache hit, $context")
             return Result.success(it)
         }
-        Logger.d(TAG, "App detail cache lookup finished: cache miss, $context")
         return runCatchingCancellable {
             val reference = AppReference.InstalledPackage(packageName)
-
-            Logger.d(TAG, "App detail package query started: $context")
-            val packageInfo = packageManager.getPackageInfo(packageName.value, analysisFlags)
-            Logger.d(TAG, "App detail package query finished: $context")
-
-            val intentFilters = manifestParser.componentIntentFilters(reference)
-            if (intentFilters.isSuccess) {
-                Logger.d(TAG, "App detail intent filters loading finished: $context")
-            } else {
-                Logger.w(TAG, "App detail intent filters loading degraded: $context")
+            val packageInfo = trace.timedStage("package query", "package_query_ms", context) {
+                packageManager.getPackageInfo(packageName.value, analysisFlags)
             }
-
-            val totalSize = storageStatsRepository.queryTotalSize(packageName)
-            if (totalSize != null) {
-                Logger.d(TAG, "App detail storage stats loading finished: $context")
-            } else {
-                Logger.w(TAG, "App detail storage stats loading degraded: data unavailable, $context")
-            }
-
-            val lastUsedTime = usageStatsRepository.queryLastUsedTime(packageName)
-            if (lastUsedTime != null) {
-                Logger.d(TAG, "App detail usage stats loading finished: $context")
-            } else {
-                Logger.w(TAG, "App detail usage stats loading degraded: data unavailable, $context")
-            }
+            val intentFilters = trace.timedStage("manifest parsing", "manifest_parse_ms", context) {
+                manifestParser.componentIntentFilters(reference)
+            }.warnIfDegraded("intent filters", context)
+            val totalSize = trace.timedStage("storage stats", "storage_stats_ms", context) {
+                storageStatsRepository.queryTotalSize(packageName)
+            }.warnIfDegraded("storage stats", context)
+            val lastUsedTime = trace.timedStage("usage stats", "usage_stats_ms", context) {
+                usageStatsRepository.queryLastUsedTime(packageName)
+            }.warnIfDegraded("usage stats", context)
 
             getPackageDetails(
+                trace = trace,
                 context = context,
                 analysisMode = AppDetail.AnalysisMode.InstalledPackage,
                 packageInfo = packageInfo,
@@ -183,37 +160,25 @@ internal class AppDetailRepositoryImpl @Inject constructor(
     private suspend fun apkFilePackageDetails(accessibleFile: File, trace: PerformanceTrace): Result<AppDetail> {
         val context = "mode=apk_file apk_path=${accessibleFile.absolutePath}"
         val cacheKey = CacheKey.ApkFile(accessibleFile.absolutePath, accessibleFile.lastModified())
-        Logger.d(TAG, "App detail loading started: $context")
-        Logger.d(TAG, "App detail cache lookup started: $context")
+        Logger.i(TAG, "App detail loading started: $context")
         val cachedDetail = cache[cacheKey]
-        trace[CACHE_HIT_ATTRIBUTE] = cachedDetail?.let { ATTRIBUTE_TRUE } ?: ATTRIBUTE_FALSE
         cachedDetail?.let {
-            Logger.d(TAG, "App detail cache lookup finished: cache hit, $context")
-            if (!it.isPerformanceDegraded) {
-                Logger.i(TAG, "App detail loading finished: cache hit, $context")
-            } else {
-                Logger.w(TAG, "App detail loading degraded: optional analysis unavailable, cache hit, $context")
-            }
+            trace[CACHE_HIT_ATTRIBUTE] = true.toString()
+            Logger.i(TAG, "App detail loading finished: cache hit, $context")
             return Result.success(it)
         }
 
-        Logger.d(TAG, "App detail cache lookup finished: cache miss, $context")
         return runCatchingCancellable {
             val reference = AppReference.ApkFile(accessibleFile.absolutePath)
-
-            Logger.d(TAG, "App detail package query started: $context")
-            val packageInfo = packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
-                ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}")
-            Logger.d(TAG, "App detail package query finished: $context")
-
-            val intentFilters = manifestParser.componentIntentFilters(reference)
-            if (intentFilters.isSuccess) {
-                Logger.d(TAG, "App detail intent filters loading finished: $context")
-            } else {
-                Logger.w(TAG, "App detail intent filters loading degraded: $context")
-            }
+            val packageInfo = trace.timedStage("package query", "package_query_ms", context) {
+                packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
+            } ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}")
+            val intentFilters = trace.timedStage("manifest parsing", "manifest_parse_ms", context) {
+                manifestParser.componentIntentFilters(reference)
+            }.warnIfDegraded("intent filters", context)
 
             getPackageDetails(
+                trace = trace,
                 context = context,
                 analysisMode = AppDetail.AnalysisMode.ApkFile,
                 packageInfo = packageInfo,
@@ -222,17 +187,14 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             )
         }.onSuccess { detail ->
             cache[cacheKey] = detail
-            if (!detail.isPerformanceDegraded) {
-                Logger.i(TAG, "App detail loading finished: $context")
-            } else {
-                Logger.w(TAG, "App detail loading degraded: optional analysis unavailable, $context")
-            }
+            Logger.i(TAG, "App detail loading finished: $context")
         }.onFailure {
             Logger.e(TAG, it, "App detail loading failed: $context")
         }
     }
 
     private fun getPackageDetails(
+        trace: PerformanceTrace,
         context: String,
         analysisMode: AppDetail.AnalysisMode,
         packageInfo: PackageInfo,
@@ -241,75 +203,89 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         totalSize: AppSize? = null,
         lastUsedTime: Instant? = null,
     ): AppDetail {
-        Logger.d(TAG, "App detail general information loading started: $context")
-        val info = getGeneralData(packageInfo, totalSize, lastUsedTime)
-        Logger.d(TAG, "App detail general information loading finished: $context")
-
-        Logger.d(TAG, "App detail certificates loading started: $context")
-        val signing = certificateExtractor.getAppSigning(packageInfo)
-        Logger.d(
-            TAG,
-            "App detail certificates loading finished: ${signing.currentCertificates.size + signing.pastCertificates.size} certificates loaded, $context",
-        )
-
-        Logger.d(TAG, "App detail signing schemes loading started: $context")
-        val signingSchemeVersions = packageInfo.applicationInfo?.sourceDir?.let(apkSigningBlockAnalyzer::detectSchemeVersions)
-        if (signingSchemeVersions != null) {
-            Logger.d(TAG, "App detail signing schemes loading finished: ${signingSchemeVersions.size} schemes loaded, $context")
-        } else {
-            Logger.w(TAG, "App detail signing schemes loading degraded: data unavailable, $context")
+        val info = trace.timedStage("general information", "general_info_ms", context) {
+            getGeneralData(packageInfo, totalSize, lastUsedTime)
         }
 
+        val signing = trace.timedStage("certificates", "certificates_ms", context) {
+            certificateExtractor.getAppSigning(packageInfo)
+        }
+
+        val signingSchemeVersions = trace.timedStage("signing schemes", "signing_schemes_ms", context) {
+            packageInfo.applicationInfo?.sourceDir?.let(apkSigningBlockAnalyzer::detectSchemeVersions)
+        }.warnIfDegraded("signing schemes", context)
+
         val launcherActivityNames = when (analysisMode) {
-            AppDetail.AnalysisMode.InstalledPackage -> {
-                Logger.d(TAG, "App detail launcher activities loading started: $context")
-                queryLauncherActivityNames(PackageName(packageInfo.packageName)).also {
-                    Logger.d(TAG, "App detail launcher activities loading finished: ${it.size} activities loaded, $context")
-                }
+            AppDetail.AnalysisMode.InstalledPackage -> trace.timedStage("launcher activities", "launcher_activities_ms", context) {
+                queryLauncherActivityNames(PackageName(packageInfo.packageName))
             }
 
             AppDetail.AnalysisMode.ApkFile -> null
         }
 
-        Logger.d(TAG, "App detail components loading started: $context")
-        val activities = getActivities(packageInfo, launcherActivityNames, intentFiltersByComponent)
-        val services = getServices(packageInfo, intentFiltersByComponent)
-        val contentProviders = getContentProviders(packageInfo, intentFiltersByComponent)
-        val receivers = getBroadcastReceivers(packageInfo, intentFiltersByComponent)
-        Logger.d(
-            TAG,
-            "App detail components loading finished: ${activities.size + services.size + contentProviders.size + receivers.size} components loaded, $context",
-        )
+        val components = trace.timedStage("components", "components_ms", context) {
+            ComponentsBundle(
+                activities = getActivities(packageInfo, launcherActivityNames, intentFiltersByComponent),
+                services = getServices(packageInfo, intentFiltersByComponent),
+                contentProviders = getContentProviders(packageInfo, intentFiltersByComponent),
+                receivers = getBroadcastReceivers(packageInfo, intentFiltersByComponent),
+            )
+        }
 
-        Logger.d(TAG, "App detail permissions loading started: $context")
-        val permissions = getPermissions(packageInfo)
-        Logger.d(
-            TAG,
-            "App detail permissions loading finished: ${permissions.used.size + permissions.defined.size} permissions loaded, $context",
-        )
+        val permissions = trace.timedStage("permissions", "permissions_ms", context) {
+            getPermissions(packageInfo)
+        }
 
-        Logger.d(TAG, "App detail features loading started: $context")
-        val features = getFeatures(packageInfo)
-        Logger.d(TAG, "App detail features loading finished: ${features.size} features loaded, $context")
+        val features = trace.timedStage("features", "features_ms", context) {
+            getFeatures(packageInfo)
+        }
 
-        Logger.d(TAG, "App detail packaging loading started: $context")
-        val nativeLibraries = readNativeLibraries(packageInfo.applicationInfo)
-        Logger.d(TAG, "App detail packaging loading finished: ${nativeLibraries.files.size} native libraries loaded, $context")
+        val nativeLibraries = trace.timedStage("packaging", "packaging_ms", context) {
+            readNativeLibraries(packageInfo.applicationInfo)
+        }
 
         return AppDetail(
             analysisMode = analysisMode,
             info = info,
             signing = signing.copy(signingSchemeVersions = signingSchemeVersions),
-            activities = activities,
-            services = services,
-            contentProviders = contentProviders,
-            receivers = receivers,
+            activities = components.activities,
+            services = components.services,
+            contentProviders = components.contentProviders,
+            receivers = components.receivers,
             permissions = permissions,
             features = features,
             nativeLibraries = nativeLibraries,
             areComponentIntentFiltersAvailable = areIntentFiltersAvailable,
         )
     }
+
+    private inline fun <T> PerformanceTrace.timedStage(
+        stage: String,
+        metric: String,
+        context: String,
+        block: () -> T,
+    ): T = timedSection(tag = TAG, operation = "App detail $stage loading", metric = metric, context = context, block = block)
+
+    private fun warnDegraded(stage: String, context: String) {
+        Logger.w(TAG, "App detail $stage loading degraded: data unavailable, $context")
+    }
+
+    private fun <T> T?.warnIfDegraded(stage: String, context: String): T? {
+        if (this == null) warnDegraded(stage, context)
+        return this
+    }
+
+    private fun <T> Result<T>.warnIfDegraded(stage: String, context: String): Result<T> {
+        if (isFailure) warnDegraded(stage, context)
+        return this
+    }
+
+    private data class ComponentsBundle(
+        val activities: List<Activity>,
+        val services: List<Service>,
+        val contentProviders: List<ContentProvider>,
+        val receivers: List<BroadcastReceiver>,
+    )
 
     private fun getGeneralData(
         packageInfo: PackageInfo,
@@ -482,46 +458,28 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         data class InstalledPackage(val packageName: PackageName) : CacheKey
         data class ApkFile(val path: String, val lastModified: Long) : CacheKey
     }
-
-    companion object {
-        private const val TAG = "AppDetailRepositoryImpl"
-
-        private val launcherCategories = listOf(Intent.CATEGORY_LAUNCHER, Intent.CATEGORY_LEANBACK_LAUNCHER)
-    }
 }
 
-private val AppReference.analysisModeAttribute: String
-    get() = when (this) {
-        is AppReference.InstalledPackage -> ANALYSIS_MODE_INSTALLED
-        is AppReference.ApkFile -> ANALYSIS_MODE_APK_FILE
-    }
+private val launcherCategories = listOf(Intent.CATEGORY_LAUNCHER, Intent.CATEGORY_LEANBACK_LAUNCHER)
 
 private val AppDetail.isPerformanceDegraded: Boolean
     get() = !areComponentIntentFiltersAvailable || signing.signingSchemeVersions == null
 
 private fun PerformanceTrace.recordResult(detail: AppDetail) {
-    this[INTENT_FILTERS_ATTRIBUTE] = if (detail.areComponentIntentFiltersAvailable) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE
-    this[SIGNING_SCHEMES_ATTRIBUTE] = if (detail.signing.signingSchemeVersions != null) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE
-    setOutcome(if (detail.isPerformanceDegraded) TraceOutcome.Degraded else TraceOutcome.Success)
+    this["intent_filters"] = if (detail.areComponentIntentFiltersAvailable) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE
+    this["signing_schemes"] = if (detail.signing.signingSchemeVersions != null) AVAILABILITY_AVAILABLE else AVAILABILITY_UNAVAILABLE
+    outcome = if (detail.isPerformanceDegraded) TraceOutcome.Degraded else TraceOutcome.Success
 }
 
 private fun PerformanceTrace.recordErrorPreserving(failure: Throwable) {
     val telemetryFailure = runCatching {
-        setOutcome(TraceOutcome.Error)
+        outcome = TraceOutcome.Error
     }.exceptionOrNull()
     if (telemetryFailure != null && telemetryFailure !== failure) {
         failure.addSuppressed(telemetryFailure)
     }
 }
 
-private const val APP_DETAIL_LOAD_TRACE = "app_detail_load"
-private const val ANALYSIS_MODE_ATTRIBUTE = "analysis_mode"
 private const val CACHE_HIT_ATTRIBUTE = "cache_hit"
-private const val INTENT_FILTERS_ATTRIBUTE = "intent_filters"
-private const val SIGNING_SCHEMES_ATTRIBUTE = "signing_schemes"
-private const val ANALYSIS_MODE_INSTALLED = "installed"
-private const val ANALYSIS_MODE_APK_FILE = "apk_file"
-private const val ATTRIBUTE_TRUE = "true"
-private const val ATTRIBUTE_FALSE = "false"
 private const val AVAILABILITY_AVAILABLE = "available"
 private const val AVAILABILITY_UNAVAILABLE = "unavailable"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -51,6 +51,7 @@ import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTrace
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.analysisMode
 import sk.styk.martin.apkanalyzer.core.common.performance.outcome
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import sk.styk.martin.apkanalyzer.core.common.performance.timedSection
@@ -98,45 +99,44 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             .launchIn(appScope + dispatcherProvider.default())
     }
 
-    override suspend fun details(reference: AppReference): Result<AppDetail> = performanceTracker.startCancellableTrace("app_detail_load") { trace ->
-        trace["analysis_mode"] = reference.analysisModeAttribute
+    override suspend fun details(reference: AppReference): Result<AppDetail> = performanceTracker.startCancellableTrace("app_detail_load") {
+        analysisMode = reference.analysisModeAttribute
         when (reference) {
-            is AppReference.InstalledPackage -> installedPackageDetails(reference.packageName, trace)
-            is AppReference.ApkFile -> apkFilePackageDetails(File(reference.path), trace)
+            is AppReference.InstalledPackage -> installedPackageDetails(reference.packageName)
+            is AppReference.ApkFile -> apkFilePackageDetails(File(reference.path))
         }.onSuccess {
-            trace.recordResult(it)
+            recordResult(it)
         }.onFailure {
-            trace.recordErrorPreserving(it)
+            recordErrorPreserving(it)
         }
     }
 
-    private suspend fun installedPackageDetails(packageName: PackageName, trace: PerformanceTrace): Result<AppDetail> {
+    private suspend fun PerformanceTrace.installedPackageDetails(packageName: PackageName): Result<AppDetail> {
         val context = "mode=installed package=${packageName.value}"
         val cacheKey = CacheKey.InstalledPackage(packageName)
         Logger.i(TAG, "App detail loading started: $context")
         val cachedDetail = cache[cacheKey]
         cachedDetail?.let {
-            trace[CACHE_HIT_ATTRIBUTE] = true.toString()
+            markCacheHit()
             Logger.i(TAG, "App detail loading finished: cache hit, $context")
             return Result.success(it)
         }
         return runCatchingCancellable {
             val reference = AppReference.InstalledPackage(packageName)
-            val packageInfo = trace.timedStage("package query", "package_query_ms", context) {
+            val packageInfo = timedStage("package query", "package_query_ms", context) {
                 packageManager.getPackageInfo(packageName.value, analysisFlags)
             }
-            val intentFilters = trace.timedStage("manifest parsing", "manifest_parse_ms", context) {
+            val intentFilters = timedStage("manifest parsing", "manifest_parse_ms", context) {
                 manifestParser.componentIntentFilters(reference)
             }.warnIfDegraded("intent filters", context)
-            val totalSize = trace.timedStage("storage stats", "storage_stats_ms", context) {
+            val totalSize = timedStage("storage stats", "storage_stats_ms", context) {
                 storageStatsRepository.queryTotalSize(packageName)
             }.warnIfDegraded("storage stats", context)
-            val lastUsedTime = trace.timedStage("usage stats", "usage_stats_ms", context) {
+            val lastUsedTime = timedStage("usage stats", "usage_stats_ms", context) {
                 usageStatsRepository.queryLastUsedTime(packageName)
             }.warnIfDegraded("usage stats", context)
 
             getPackageDetails(
-                trace = trace,
                 context = context,
                 analysisMode = AppDetail.AnalysisMode.InstalledPackage,
                 packageInfo = packageInfo,
@@ -157,28 +157,27 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         }
     }
 
-    private suspend fun apkFilePackageDetails(accessibleFile: File, trace: PerformanceTrace): Result<AppDetail> {
+    private suspend fun PerformanceTrace.apkFilePackageDetails(accessibleFile: File): Result<AppDetail> {
         val context = "mode=apk_file apk_path=${accessibleFile.absolutePath}"
         val cacheKey = CacheKey.ApkFile(accessibleFile.absolutePath, accessibleFile.lastModified())
         Logger.i(TAG, "App detail loading started: $context")
         val cachedDetail = cache[cacheKey]
         cachedDetail?.let {
-            trace[CACHE_HIT_ATTRIBUTE] = true.toString()
+            markCacheHit()
             Logger.i(TAG, "App detail loading finished: cache hit, $context")
             return Result.success(it)
         }
 
         return runCatchingCancellable {
             val reference = AppReference.ApkFile(accessibleFile.absolutePath)
-            val packageInfo = trace.timedStage("package query", "package_query_ms", context) {
+            val packageInfo = timedStage("package query", "package_query_ms", context) {
                 packageManager.getPackageArchiveInfoWithCorrectPath(accessibleFile.absolutePath, analysisFlags)
             } ?: error("Cannot parse APK file: ${accessibleFile.absolutePath}")
-            val intentFilters = trace.timedStage("manifest parsing", "manifest_parse_ms", context) {
+            val intentFilters = timedStage("manifest parsing", "manifest_parse_ms", context) {
                 manifestParser.componentIntentFilters(reference)
             }.warnIfDegraded("intent filters", context)
 
             getPackageDetails(
-                trace = trace,
                 context = context,
                 analysisMode = AppDetail.AnalysisMode.ApkFile,
                 packageInfo = packageInfo,
@@ -193,8 +192,7 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun getPackageDetails(
-        trace: PerformanceTrace,
+    private fun PerformanceTrace.getPackageDetails(
         context: String,
         analysisMode: AppDetail.AnalysisMode,
         packageInfo: PackageInfo,
@@ -203,27 +201,27 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         totalSize: AppSize? = null,
         lastUsedTime: Instant? = null,
     ): AppDetail {
-        val info = trace.timedStage("general information", "general_info_ms", context) {
+        val info = timedStage("general information", "general_info_ms", context) {
             getGeneralData(packageInfo, totalSize, lastUsedTime)
         }
 
-        val signing = trace.timedStage("certificates", "certificates_ms", context) {
+        val signing = timedStage("certificates", "certificates_ms", context) {
             certificateExtractor.getAppSigning(packageInfo)
         }
 
-        val signingSchemeVersions = trace.timedStage("signing schemes", "signing_schemes_ms", context) {
+        val signingSchemeVersions = timedStage("signing schemes", "signing_schemes_ms", context) {
             packageInfo.applicationInfo?.sourceDir?.let(apkSigningBlockAnalyzer::detectSchemeVersions)
         }.warnIfDegraded("signing schemes", context)
 
         val launcherActivityNames = when (analysisMode) {
-            AppDetail.AnalysisMode.InstalledPackage -> trace.timedStage("launcher activities", "launcher_activities_ms", context) {
+            AppDetail.AnalysisMode.InstalledPackage -> timedStage("launcher activities", "launcher_activities_ms", context) {
                 queryLauncherActivityNames(PackageName(packageInfo.packageName))
             }
 
             AppDetail.AnalysisMode.ApkFile -> null
         }
 
-        val components = trace.timedStage("components", "components_ms", context) {
+        val components = timedStage("components", "components_ms", context) {
             ComponentsBundle(
                 activities = getActivities(packageInfo, launcherActivityNames, intentFiltersByComponent),
                 services = getServices(packageInfo, intentFiltersByComponent),
@@ -232,15 +230,15 @@ internal class AppDetailRepositoryImpl @Inject constructor(
             )
         }
 
-        val permissions = trace.timedStage("permissions", "permissions_ms", context) {
+        val permissions = timedStage("permissions", "permissions_ms", context) {
             getPermissions(packageInfo)
         }
 
-        val features = trace.timedStage("features", "features_ms", context) {
+        val features = timedStage("features", "features_ms", context) {
             getFeatures(packageInfo)
         }
 
-        val nativeLibraries = trace.timedStage("packaging", "packaging_ms", context) {
+        val nativeLibraries = timedStage("packaging", "packaging_ms", context) {
             readNativeLibraries(packageInfo.applicationInfo)
         }
 
@@ -265,6 +263,10 @@ internal class AppDetailRepositoryImpl @Inject constructor(
         context: String,
         block: () -> T,
     ): T = timedSection(tag = TAG, operation = "App detail $stage loading", metric = metric, context = context, block = block)
+
+    private fun PerformanceTrace.markCacheHit() {
+        this[CACHE_HIT_ATTRIBUTE] = true.toString()
+    }
 
     private fun warnDegraded(stage: String, context: String) {
         Logger.w(TAG, "App detail $stage loading degraded: data unavailable, $context")

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppDetailRepositoryImpl.kt
@@ -52,6 +52,7 @@ import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTrace
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
 import sk.styk.martin.apkanalyzer.core.common.performance.analysisMode
+import sk.styk.martin.apkanalyzer.core.common.performance.analysisModeAttribute
 import sk.styk.martin.apkanalyzer.core.common.performance.outcome
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import sk.styk.martin.apkanalyzer.core.common.performance.timedSection

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppReferenceTraceAttribute.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppReferenceTraceAttribute.kt
@@ -1,9 +1,0 @@
-package sk.styk.martin.apkanalyzer.core.apps
-
-import sk.styk.martin.apkanalyzer.core.common.model.AppReference
-
-internal val AppReference.analysisModeAttribute: String
-    get() = when (this) {
-        is AppReference.InstalledPackage -> "installed"
-        is AppReference.ApkFile -> "apk_file"
-    }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppReferenceTraceAttribute.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/AppReferenceTraceAttribute.kt
@@ -1,0 +1,9 @@
+package sk.styk.martin.apkanalyzer.core.apps
+
+import sk.styk.martin.apkanalyzer.core.common.model.AppReference
+
+internal val AppReference.analysisModeAttribute: String
+    get() = when (this) {
+        is AppReference.InstalledPackage -> "installed"
+        is AppReference.ApkFile -> "apk_file"
+    }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -28,6 +28,7 @@ import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.appCount
 import sk.styk.martin.apkanalyzer.core.common.performance.outcome
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import sk.styk.martin.apkanalyzer.core.common.performance.timedSection
@@ -74,26 +75,26 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
     override fun apps(): Flow<List<InstalledApp>> = cachedApps
 
     @SuppressLint("QueryPermissionsNeeded")
-    private suspend fun loadAllApps(): List<InstalledApp> = performanceTracker.startCancellableTrace("installed_apps_load") { trace ->
+    private suspend fun loadAllApps(): List<InstalledApp> = performanceTracker.startCancellableTrace("installed_apps_load") {
         Logger.i(INSTALLED_APPS, "Installed apps loading started")
         runCatchingCancellable {
-            val packages = trace.timedSection(tag = INSTALLED_APPS, operation = "Installed apps package query", metric = "package_query_ms") {
+            val packages = timedSection(tag = INSTALLED_APPS, operation = "Installed apps package query", metric = "package_query_ms") {
                 packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
             }
 
-            val apps = trace.timedSection(tag = INSTALLED_APPS, operation = "Installed apps mapping", metric = "apps_mapping_ms") {
+            val apps = timedSection(tag = INSTALLED_APPS, operation = "Installed apps mapping", metric = "apps_mapping_ms") {
                 packages.mapNotNull { packageInfo -> packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() } }
             }
-            trace["app_count"] = apps.size
+            appCount = apps.size
             apps
         }.fold(
             onSuccess = { apps ->
-                trace.outcome = TraceOutcome.Success
+                outcome = TraceOutcome.Success
                 Logger.i(INSTALLED_APPS, "Installed apps loading finished: ${apps.size} apps loaded")
                 apps
             },
             onFailure = { failure ->
-                trace.outcome = TraceOutcome.Error
+                outcome = TraceOutcome.Error
                 Logger.e(INSTALLED_APPS, failure, "Installed apps loading failed")
                 emptyList()
             },

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/InstalledAppsRepositoryImpl.kt
@@ -28,11 +28,12 @@ import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.outcome
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
+import sk.styk.martin.apkanalyzer.core.common.performance.timedSection
 import java.io.File
 import java.time.Instant
 import javax.inject.Inject
-import kotlin.time.measureTimedValue
 
 internal const val INSTALLED_APPS = "InstalledApps"
 
@@ -74,33 +75,27 @@ internal class InstalledAppsRepositoryImpl @Inject constructor(
 
     @SuppressLint("QueryPermissionsNeeded")
     private suspend fun loadAllApps(): List<InstalledApp> = performanceTracker.startCancellableTrace("installed_apps_load") { trace ->
-        Logger.d(INSTALLED_APPS, "Installed apps loading started")
+        Logger.i(INSTALLED_APPS, "Installed apps loading started")
         runCatchingCancellable {
-            Logger.d(INSTALLED_APPS, "Installed apps package query started")
-            val packageQuery = measureTimedValue {
+            val packages = trace.timedSection(tag = INSTALLED_APPS, operation = "Installed apps package query", metric = "package_query_ms") {
                 packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
             }
-            val packages = packageQuery.value
-            trace["package_query_ms"] = packageQuery.duration.inWholeMilliseconds
-            Logger.d(INSTALLED_APPS, "Installed apps package query finished: ${packages.size} packages found")
 
-            Logger.d(INSTALLED_APPS, "Installed apps mapping started")
-            val apps = packages.mapNotNull { packageInfo ->
-                packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() }
+            val apps = trace.timedSection(tag = INSTALLED_APPS, operation = "Installed apps mapping", metric = "apps_mapping_ms") {
+                packages.mapNotNull { packageInfo -> packageInfo.applicationInfo?.let { packageInfo.toInstalledApp() } }
             }
-            trace["app_count"] = apps.size.toLong()
-            Logger.d(INSTALLED_APPS, "Installed apps mapping finished: ${apps.size} apps mapped")
+            trace["app_count"] = apps.size
             apps
         }.fold(
             onSuccess = { apps ->
-                trace.setOutcome(TraceOutcome.Success)
+                trace.outcome = TraceOutcome.Success
                 Logger.i(INSTALLED_APPS, "Installed apps loading finished: ${apps.size} apps loaded")
                 apps
             },
             onFailure = { failure ->
-                trace.setOutcome(TraceOutcome.Error)
+                trace.outcome = TraceOutcome.Error
                 Logger.e(INSTALLED_APPS, failure, "Installed apps loading failed")
-                throw failure
+                emptyList()
             },
         )
     }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
@@ -3,6 +3,7 @@ package sk.styk.martin.apkanalyzer.core.apps.manifest
 import android.content.pm.PackageManager
 import android.content.res.Resources
 import kotlinx.coroutines.withContext
+import sk.styk.martin.apkanalyzer.core.apps.analysisModeAttribute
 import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilter
 import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilterKey
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
@@ -10,6 +11,10 @@ import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.outcome
+import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import javax.inject.Inject
 
 private const val TAG = "ManifestParser"
@@ -19,20 +24,21 @@ internal class ManifestParserImpl @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val manifestXmlRenderer: ManifestXmlRenderer,
     private val componentManifestParser: ComponentManifestParser,
+    private val performanceTracker: PerformanceTracker,
 ) : ManifestParser {
 
-    override suspend fun manifest(reference: AppReference): Result<ParsedManifest> = when (reference) {
-        is AppReference.InstalledPackage -> installedPackageManifest(reference.packageName)
-        is AppReference.ApkFile -> apkFileManifest(reference.path)
+    override suspend fun manifest(reference: AppReference): Result<ParsedManifest> = performanceTracker.startCancellableTrace("manifest_load") { trace ->
+        trace["analysis_mode"] = reference.analysisModeAttribute
+        val result = when (reference) {
+            is AppReference.InstalledPackage -> installedPackageManifest(reference.packageName)
+            is AppReference.ApkFile -> apkFileManifest(reference.path)
+        }
+        trace.outcome = if (result.isSuccess) TraceOutcome.Success else TraceOutcome.Error
+        result
     }
 
-    override suspend fun componentIntentFilters(reference: AppReference): Result<Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>> {
-        val context = when (reference) {
-            is AppReference.InstalledPackage -> "mode=installed package=${reference.packageName.value}"
-            is AppReference.ApkFile -> "mode=apk_file apk_path=${reference.path}"
-        }
-        Logger.d(TAG, "Component intent filters loading started: $context")
-        return withContext(dispatcherProvider.io()) {
+    override suspend fun componentIntentFilters(reference: AppReference): Result<Map<ComponentIntentFilterKey, List<ComponentIntentFilter>>> =
+        withContext(dispatcherProvider.io()) {
             runCatchingCancellable {
                 when (reference) {
                     is AppReference.InstalledPackage -> installedComponentIntentFilters(reference.packageName)
@@ -44,12 +50,7 @@ internal class ManifestParserImpl @Inject constructor(
                     )
                     .mapValues { (_, filters) -> filters.distinct() }
             }
-        }.onSuccess {
-            Logger.d(TAG, "Component intent filters loading finished: ${it.size} components loaded, $context")
-        }.onFailure {
-            Logger.w(TAG, it, "Component intent filters loading degraded: $context")
         }
-    }
 
     private suspend fun installedPackageManifest(packageName: PackageName): Result<ParsedManifest> {
         val context = "mode=installed package=${packageName.value}"

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
@@ -13,6 +13,7 @@ import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.analysisMode
 import sk.styk.martin.apkanalyzer.core.common.performance.outcome
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import javax.inject.Inject
@@ -27,13 +28,13 @@ internal class ManifestParserImpl @Inject constructor(
     private val performanceTracker: PerformanceTracker,
 ) : ManifestParser {
 
-    override suspend fun manifest(reference: AppReference): Result<ParsedManifest> = performanceTracker.startCancellableTrace("manifest_load") { trace ->
-        trace["analysis_mode"] = reference.analysisModeAttribute
+    override suspend fun manifest(reference: AppReference): Result<ParsedManifest> = performanceTracker.startCancellableTrace("manifest_load") {
+        analysisMode = reference.analysisModeAttribute
         val result = when (reference) {
             is AppReference.InstalledPackage -> installedPackageManifest(reference.packageName)
             is AppReference.ApkFile -> apkFileManifest(reference.path)
         }
-        trace.outcome = if (result.isSuccess) TraceOutcome.Success else TraceOutcome.Error
+        outcome = if (result.isSuccess) TraceOutcome.Success else TraceOutcome.Error
         result
     }
 

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/manifest/ManifestParserImpl.kt
@@ -3,7 +3,6 @@ package sk.styk.martin.apkanalyzer.core.apps.manifest
 import android.content.pm.PackageManager
 import android.content.res.Resources
 import kotlinx.coroutines.withContext
-import sk.styk.martin.apkanalyzer.core.apps.analysisModeAttribute
 import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilter
 import sk.styk.martin.apkanalyzer.core.apps.components.ComponentIntentFilterKey
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
@@ -14,6 +13,7 @@ import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
 import sk.styk.martin.apkanalyzer.core.common.performance.analysisMode
+import sk.styk.martin.apkanalyzer.core.common.performance.analysisModeAttribute
 import sk.styk.martin.apkanalyzer.core.common.performance.outcome
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
 import javax.inject.Inject

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
@@ -41,22 +41,22 @@ internal class AppSigningRepositoryImpl @Inject constructor(
     override fun signing(): Flow<Map<PackageName, AppSigning>> = cachedSigning
 
     @SuppressLint("QueryPermissionsNeeded")
-    private suspend fun loadAllSigning(): Map<PackageName, AppSigning> = performanceTracker.startCancellableTrace("app_signing_index_load") { trace ->
+    private suspend fun loadAllSigning(): Map<PackageName, AppSigning> = performanceTracker.startCancellableTrace("app_signing_index_load") {
         runCatchingCancellable {
-            val packages = trace.timedSection(tag = TAG, operation = "App signing package query", metric = "package_query_ms") {
+            val packages = timedSection(tag = TAG, operation = "App signing package query", metric = "package_query_ms") {
                 packageManager.getInstalledPackages(PackageManager.GET_SIGNING_CERTIFICATES)
             }
-            trace.timedSection(tag = TAG, operation = "App signing extraction", metric = "signing_extraction_ms") {
+            timedSection(tag = TAG, operation = "App signing extraction", metric = "signing_extraction_ms") {
                 packages.associate { PackageName(it.packageName) to certificateExtractor.getAppSigning(it) }
             }
         }.fold(
             onSuccess = { signing ->
-                trace.outcome = TraceOutcome.Success
+                outcome = TraceOutcome.Success
                 Logger.i(TAG, "App signing index loading finished: ${signing.size} apps loaded")
                 signing
             },
             onFailure = { failure ->
-                trace.outcome = TraceOutcome.Error
+                outcome = TraceOutcome.Error
                 Logger.e(TAG, failure, "App signing index loading failed")
                 emptyMap()
             },

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/signing/AppSigningRepositoryImpl.kt
@@ -11,10 +11,15 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import sk.styk.martin.apkanalyzer.core.apps.PackageChangesObserver
 import sk.styk.martin.apkanalyzer.core.common.coroutines.DispatcherProvider
+import sk.styk.martin.apkanalyzer.core.common.coroutines.runCatchingCancellable
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
 import sk.styk.martin.apkanalyzer.core.common.model.PackageName
+import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
+import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
+import sk.styk.martin.apkanalyzer.core.common.performance.outcome
+import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
+import sk.styk.martin.apkanalyzer.core.common.performance.timedSection
 import javax.inject.Inject
-import kotlin.coroutines.cancellation.CancellationException
 
 private const val TAG = "AppSigningRepositoryImpl"
 
@@ -24,30 +29,37 @@ internal class AppSigningRepositoryImpl @Inject constructor(
     packageChangesObserver: PackageChangesObserver,
     dispatcherProvider: DispatcherProvider,
     appScope: CoroutineScope,
+    private val performanceTracker: PerformanceTracker,
 ) : AppSigningRepository {
 
-    @Suppress("TooGenericExceptionCaught")
     private val cachedSigning = packageChangesObserver.observe()
         .onStart { emit(Unit) }
-        .mapLatest {
-            Logger.d(TAG, "App signing index loading started")
-            try {
-                val result = loadAllSigning()
-                Logger.i(TAG, "App signing index loading finished: ${result.size} apps loaded")
-                result
-            } catch (failure: Throwable) {
-                if (failure !is CancellationException) {
-                    Logger.e(TAG, failure, "App signing index loading failed")
-                }
-                throw failure
-            }
-        }
+        .mapLatest { loadAllSigning() }
         .flowOn(dispatcherProvider.io())
         .shareIn(appScope, SharingStarted.Lazily, replay = 1)
 
     override fun signing(): Flow<Map<PackageName, AppSigning>> = cachedSigning
 
     @SuppressLint("QueryPermissionsNeeded")
-    private fun loadAllSigning(): Map<PackageName, AppSigning> = packageManager.getInstalledPackages(PackageManager.GET_SIGNING_CERTIFICATES)
-        .associate { PackageName(it.packageName) to certificateExtractor.getAppSigning(it) }
+    private suspend fun loadAllSigning(): Map<PackageName, AppSigning> = performanceTracker.startCancellableTrace("app_signing_index_load") { trace ->
+        runCatchingCancellable {
+            val packages = trace.timedSection(tag = TAG, operation = "App signing package query", metric = "package_query_ms") {
+                packageManager.getInstalledPackages(PackageManager.GET_SIGNING_CERTIFICATES)
+            }
+            trace.timedSection(tag = TAG, operation = "App signing extraction", metric = "signing_extraction_ms") {
+                packages.associate { PackageName(it.packageName) to certificateExtractor.getAppSigning(it) }
+            }
+        }.fold(
+            onSuccess = { signing ->
+                trace.outcome = TraceOutcome.Success
+                Logger.i(TAG, "App signing index loading finished: ${signing.size} apps loaded")
+                signing
+            },
+            onFailure = { failure ->
+                trace.outcome = TraceOutcome.Error
+                Logger.e(TAG, failure, "App signing index loading failed")
+                emptyMap()
+            },
+        )
+    }
 }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -92,11 +92,11 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
     }
 
     private suspend fun fetchTotalSizes(packageNames: List<PackageName>, trigger: String) {
-        performanceTracker.startCancellableTrace("storage_stats_load") { trace ->
-            trace["trigger"] = trigger
+        performanceTracker.startCancellableTrace("storage_stats_load") {
+            this["trigger"] = trigger
             runCatchingCancellable {
                 val hasPermission = checkPermission()
-                trace.permission = if (hasPermission) TracePermission.Granted else TracePermission.Denied
+                permission = if (hasPermission) TracePermission.Granted else TracePermission.Denied
                 isPermissionGranted.value = hasPermission
 
                 if (!hasPermission) {
@@ -108,7 +108,7 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
                     var permissionRaceCount = 0
                     var queryFailureCount = 0
                     var lastQueryFailure: IOException? = null
-                    val sizes = trace.timedSection(
+                    val sizes = timedSection(
                         tag = TAG,
                         operation = "Storage stats query",
                         metric = "storage_stats_query_ms",
@@ -158,9 +158,9 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
                     }
                 }
             }.fold(
-                onSuccess = { trace.outcome = it },
+                onSuccess = { outcome = it },
                 onFailure = { failure ->
-                    trace.outcome = TraceOutcome.Error
+                    outcome = TraceOutcome.Error
                     Logger.e(TAG, failure, "Storage stats loading failed")
                 },
             )

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/storagestats/StorageStatsRepositoryImpl.kt
@@ -23,7 +23,10 @@ import sk.styk.martin.apkanalyzer.core.common.model.bytes
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
 import sk.styk.martin.apkanalyzer.core.common.performance.TracePermission
+import sk.styk.martin.apkanalyzer.core.common.performance.outcome
+import sk.styk.martin.apkanalyzer.core.common.performance.permission
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
+import sk.styk.martin.apkanalyzer.core.common.performance.timedSection
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -93,40 +96,46 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
             trace["trigger"] = trigger
             runCatchingCancellable {
                 val hasPermission = checkPermission()
-                trace.setPermission(if (hasPermission) TracePermission.Granted else TracePermission.Denied)
+                trace.permission = if (hasPermission) TracePermission.Granted else TracePermission.Denied
                 isPermissionGranted.value = hasPermission
 
                 if (!hasPermission) {
                     Logger.w(TAG, "Storage stats loading degraded: permission missing")
                     TraceOutcome.Degraded
                 } else {
-                    Logger.d(TAG, "Storage stats loading started: ${packageNames.size} apps requested")
                     val user = UserHandle.getUserHandleForUid(Process.myUid())
                     var uninstallRaceCount = 0
                     var permissionRaceCount = 0
                     var queryFailureCount = 0
                     var lastQueryFailure: IOException? = null
-                    val sizes = packageNames.mapNotNull { packageName ->
-                        when (val queryResult = queryPackageSize(user, packageName)) {
-                            is SizeQueryResult.Success -> packageName to queryResult.size
+                    val sizes = trace.timedSection(
+                        tag = TAG,
+                        operation = "Storage stats query",
+                        metric = "storage_stats_query_ms",
+                        context = "${packageNames.size} apps requested",
+                    ) {
+                        packageNames.mapNotNull { packageName ->
+                            when (val queryResult = queryPackageSize(user, packageName)) {
+                                is SizeQueryResult.Success -> packageName to queryResult.size
 
-                            SizeQueryResult.UninstallRace -> {
-                                uninstallRaceCount++
-                                null
-                            }
+                                SizeQueryResult.UninstallRace -> {
+                                    uninstallRaceCount++
+                                    null
+                                }
 
-                            SizeQueryResult.PermissionRace -> {
-                                permissionRaceCount++
-                                null
-                            }
+                                SizeQueryResult.PermissionRace -> {
+                                    permissionRaceCount++
+                                    null
+                                }
 
-                            is SizeQueryResult.Failure -> {
-                                queryFailureCount++
-                                lastQueryFailure = queryResult.error
-                                null
+                                is SizeQueryResult.Failure -> {
+                                    queryFailureCount++
+                                    lastQueryFailure = queryResult.error
+                                    null
+                                }
                             }
-                        }
-                    }.toMap()
+                        }.toMap()
+                    }
                     totalSizes.value = sizes
 
                     if (uninstallRaceCount > 0) {
@@ -149,11 +158,10 @@ internal class StorageStatsRepositoryImpl @Inject constructor(
                     }
                 }
             }.fold(
-                onSuccess = trace::setOutcome,
+                onSuccess = { trace.outcome = it },
                 onFailure = { failure ->
-                    trace.setOutcome(TraceOutcome.Error)
+                    trace.outcome = TraceOutcome.Error
                     Logger.e(TAG, failure, "Storage stats loading failed")
-                    throw failure
                 },
             )
         }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
@@ -19,7 +19,10 @@ import sk.styk.martin.apkanalyzer.core.common.model.PackageName
 import sk.styk.martin.apkanalyzer.core.common.performance.PerformanceTracker
 import sk.styk.martin.apkanalyzer.core.common.performance.TraceOutcome
 import sk.styk.martin.apkanalyzer.core.common.performance.TracePermission
+import sk.styk.martin.apkanalyzer.core.common.performance.outcome
+import sk.styk.martin.apkanalyzer.core.common.performance.permission
 import sk.styk.martin.apkanalyzer.core.common.performance.startCancellableTrace
+import sk.styk.martin.apkanalyzer.core.common.performance.timedSection
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -64,15 +67,17 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
         performanceTracker.startCancellableTrace("usage_stats_load") { trace ->
             runCatchingCancellable {
                 val hasPermission = checkPermission()
-                trace.setPermission(if (hasPermission) TracePermission.Granted else TracePermission.Denied)
+                trace.permission = if (hasPermission) TracePermission.Granted else TracePermission.Denied
                 isPermissionGranted.value = hasPermission
 
                 if (!hasPermission) {
                     Logger.w(TAG, "Usage stats loading degraded: permission missing")
                     TraceOutcome.Degraded
                 } else {
-                    Logger.d(TAG, "Usage stats loading started")
-                    val usages = queryRawUsageStats()
+                    val rawUsages = trace.timedSection(tag = TAG, operation = "Usage stats query", metric = "usage_stats_query_ms") {
+                        queryRawUsageStats()
+                    }
+                    val usages = rawUsages
                         .groupBy { PackageName(it.packageName) }
                         .mapValues { (_, usages) -> Instant.ofEpochMilli(usages.maxOf { it.lastTimeUsed }) }
                     lastUsedTimes.value = usages
@@ -80,11 +85,10 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
                     TraceOutcome.Success
                 }
             }.fold(
-                onSuccess = trace::setOutcome,
+                onSuccess = { trace.outcome = it },
                 onFailure = { failure ->
-                    trace.setOutcome(TraceOutcome.Error)
+                    trace.outcome = TraceOutcome.Error
                     Logger.e(TAG, failure, "Usage stats loading failed")
-                    throw failure
                 },
             )
         }

--- a/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
+++ b/core/apps/src/main/kotlin/sk/styk/martin/apkanalyzer/core/apps/usagestats/UsageStatsRepositoryImpl.kt
@@ -64,17 +64,17 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
     }
 
     private suspend fun fetchUsageTimes() {
-        performanceTracker.startCancellableTrace("usage_stats_load") { trace ->
+        performanceTracker.startCancellableTrace("usage_stats_load") {
             runCatchingCancellable {
                 val hasPermission = checkPermission()
-                trace.permission = if (hasPermission) TracePermission.Granted else TracePermission.Denied
+                permission = if (hasPermission) TracePermission.Granted else TracePermission.Denied
                 isPermissionGranted.value = hasPermission
 
                 if (!hasPermission) {
                     Logger.w(TAG, "Usage stats loading degraded: permission missing")
                     TraceOutcome.Degraded
                 } else {
-                    val rawUsages = trace.timedSection(tag = TAG, operation = "Usage stats query", metric = "usage_stats_query_ms") {
+                    val rawUsages = timedSection(tag = TAG, operation = "Usage stats query", metric = "usage_stats_query_ms") {
                         queryRawUsageStats()
                     }
                     val usages = rawUsages
@@ -85,9 +85,9 @@ internal class UsageStatsRepositoryImpl @Inject constructor(
                     TraceOutcome.Success
                 }
             }.fold(
-                onSuccess = { trace.outcome = it },
+                onSuccess = { outcome = it },
                 onFailure = { failure ->
-                    trace.outcome = TraceOutcome.Error
+                    outcome = TraceOutcome.Error
                     Logger.e(TAG, failure, "Usage stats loading failed")
                 },
             )

--- a/core/common/AGENTS.md
+++ b/core/common/AGENTS.md
@@ -28,10 +28,17 @@ logic do not belong here.
   events, formatter helpers, or logging-only wrapper functions.
 * Throwable-bearing WARN and ERROR logs record Crashlytics non-fatals. Attach the throwable once at
   the boundary that owns the degraded result or terminal failure.
+* Crashlytics only receives INFO and above (`Logger.d`/`Logger.v` never reach it). Its `.log()` buffer
+  is a limited-size breadcrumb trail sent only alongside a crash or non-fatal, not a live stream —
+  DEBUG-level per-stage detail belongs in local logcat only, or it crowds out the breadcrumbs that
+  matter by the time a crash actually happens.
 * Firebase Performance imports stay inside the internal adapter in this infrastructure module.
   Domain core modules and feature modules depend only on `PerformanceTracker` and
   `PerformanceTrace`. This module already owns the Firebase-backed logging facade, while the app
   convention plugin remains responsible for packaging and instrumenting the SDK.
+* Time an expensive stage with `PerformanceTrace.measuredSection` (records a metric, no logging) or
+  `PerformanceTrace.timedSection` (same, plus a paired DEBUG started/finished log) instead of calling
+  `measureTimedValue` and setting the trace metric by hand at each call site.
 * `AppReference` is the shared type-safe distinction between an installed package and an APK file.
 * `AppSource.isSideloaded` intentionally groups sideloaded, local-install, and unknown sources while
   excluding recognized stores and system-preinstalled apps.

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/logger/Logger.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/logger/Logger.kt
@@ -39,6 +39,7 @@ object Logger {
             message: String,
             t: Throwable?,
         ) {
+            if (priority < Log.INFO) return
             FirebaseCrashlytics.getInstance().log("${priority.toPriorityChar()}/${tag.orEmpty()}: $message")
             if (priority >= Log.WARN && t != null) {
                 FirebaseCrashlytics.getInstance().recordException(t)
@@ -48,9 +49,7 @@ object Logger {
         private fun Int.toPriorityChar() = when (this) {
             Log.ASSERT, Log.ERROR -> 'E'
             Log.WARN -> 'W'
-            Log.INFO -> 'I'
-            Log.DEBUG -> 'D'
-            else -> 'V'
+            else -> 'I'
         }
     }
 }

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/FirebasePerformanceTrace.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/FirebasePerformanceTrace.kt
@@ -3,8 +3,8 @@ package sk.styk.martin.apkanalyzer.core.common.performance
 import com.google.firebase.perf.metrics.Trace
 
 internal class FirebasePerformanceTrace(private val trace: Trace) : PerformanceTrace {
-    override fun set(name: String, value: Long) {
-        trace.putMetric(name, value)
+    override fun set(name: String, value: Number) {
+        trace.putMetric(name, value.toLong())
     }
 
     override fun set(name: String, value: String) {

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTrace.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTrace.kt
@@ -1,18 +1,45 @@
 package sk.styk.martin.apkanalyzer.core.common.performance
 
+import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import kotlin.time.measureTimedValue
+
 interface PerformanceTrace : AutoCloseable {
-    operator fun set(name: String, value: Long)
+    operator fun set(name: String, value: Number)
 
     operator fun set(name: String, value: String)
-
-    fun setOutcome(outcome: TraceOutcome) {
-        this["outcome"] = outcome.attributeValue
-    }
-
-    fun setPermission(permission: TracePermission) {
-        this["permission"] = permission.attributeValue
-    }
 }
+
+inline fun <T> PerformanceTrace.measuredSection(metric: String, block: () -> T): T {
+    val (value, duration) = measureTimedValue(block)
+    this[metric] = duration.inWholeMilliseconds
+    return value
+}
+
+inline fun <T> PerformanceTrace.timedSection(
+    tag: String,
+    operation: String,
+    metric: String,
+    context: String = "",
+    block: () -> T,
+): T {
+    val suffix = if (context.isEmpty()) "" else ": $context"
+    Logger.d(tag, "$operation started$suffix")
+    val result = measuredSection(metric, block)
+    Logger.d(tag, "$operation finished$suffix")
+    return result
+}
+
+var PerformanceTrace.outcome: TraceOutcome
+    get() = throw UnsupportedOperationException("PerformanceTrace.outcome is write-only")
+    set(value) {
+        this["outcome"] = value.attributeValue
+    }
+
+var PerformanceTrace.permission: TracePermission
+    get() = throw UnsupportedOperationException("PerformanceTrace.permission is write-only")
+    set(value) {
+        this["permission"] = value.attributeValue
+    }
 
 enum class TraceOutcome(internal val attributeValue: String) {
     Success("success"),

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTrace.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTrace.kt
@@ -41,6 +41,18 @@ var PerformanceTrace.permission: TracePermission
         this["permission"] = value.attributeValue
     }
 
+var PerformanceTrace.analysisMode: String
+    get() = throw UnsupportedOperationException("PerformanceTrace.analysisMode is write-only")
+    set(value) {
+        this["analysis_mode"] = value
+    }
+
+var PerformanceTrace.appCount: Int
+    get() = throw UnsupportedOperationException("PerformanceTrace.appCount is write-only")
+    set(value) {
+        this["app_count"] = value
+    }
+
 enum class TraceOutcome(internal val attributeValue: String) {
     Success("success"),
     Degraded("degraded"),

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTrace.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTrace.kt
@@ -1,6 +1,7 @@
 package sk.styk.martin.apkanalyzer.core.common.performance
 
 import sk.styk.martin.apkanalyzer.core.common.logger.Logger
+import sk.styk.martin.apkanalyzer.core.common.model.AppReference
 import kotlin.time.measureTimedValue
 
 interface PerformanceTrace : AutoCloseable {
@@ -51,6 +52,12 @@ var PerformanceTrace.appCount: Int
     get() = throw UnsupportedOperationException("PerformanceTrace.appCount is write-only")
     set(value) {
         this["app_count"] = value
+    }
+
+val AppReference.analysisModeAttribute: String
+    get() = when (this) {
+        is AppReference.InstalledPackage -> "installed"
+        is AppReference.ApkFile -> "apk_file"
     }
 
 enum class TraceOutcome(internal val attributeValue: String) {

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
@@ -17,7 +17,7 @@ suspend fun <T> PerformanceTracker.startCancellableTrace(name: String, block: su
 
 private fun PerformanceTrace.recordCancellation(cancellation: CancellationException) {
     val outcomeFailure = runCatching {
-        setOutcome(TraceOutcome.Cancelled)
+        outcome = TraceOutcome.Cancelled
     }.exceptionOrNull()
     if (outcomeFailure != null && outcomeFailure !== cancellation) {
         cancellation.addSuppressed(outcomeFailure)

--- a/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
+++ b/core/common/src/main/kotlin/sk/styk/martin/apkanalyzer/core/common/performance/PerformanceTracker.kt
@@ -6,9 +6,9 @@ interface PerformanceTracker {
     fun startTrace(name: String): PerformanceTrace
 }
 
-suspend fun <T> PerformanceTracker.startCancellableTrace(name: String, block: suspend (PerformanceTrace) -> T): T = startTrace(name).use { trace ->
+suspend fun <T> PerformanceTracker.startCancellableTrace(name: String, block: suspend PerformanceTrace.() -> T): T = startTrace(name).use { trace ->
     try {
-        block(trace)
+        trace.block()
     } catch (cancellation: CancellationException) {
         trace.recordCancellation(cancellation)
         throw cancellation

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -73,11 +73,16 @@ inside per-item loops; report a bounded count when the stage finishes.
 
 | Level | Use | Crashlytics behavior |
 |---|---|---|
-| `DEBUG` | Operation/stage start, cache hit/miss, expected absence, and successful internal stages | Breadcrumb only |
+| `DEBUG` | Operation/stage start, cache hit/miss, expected absence, and successful internal stages | Local logcat only, not forwarded |
 | `INFO` | Successful completion of a public repository load or a process-level reload | Breadcrumb only |
 | `WARN` without `Throwable` | Unusual but expected or fully handled state, such as missing usage permission, an uninstall race, unsupported signing data, or unavailable optional metadata | Breadcrumb only |
 | `WARN` with `Throwable` | Unexpected recoverable failure where the operation returns a useful but degraded result | One non-fatal report with diagnostic context |
 | `ERROR` with `Throwable` | Unexpected failure that makes the parent operation fail | One non-fatal report with diagnostic context |
+
+`FirebaseTree` (`core:common`) drops anything below `INFO` before it reaches
+`FirebaseCrashlytics.log(...)`. Crashlytics's log buffer is small and only sent alongside a crash or
+non-fatal, so per-stage DEBUG detail — now emitted routinely by `timedSection` across every timed
+repository — would otherwise crowd out the breadcrumbs that matter by the time a crash happens.
 
 Do not use `ERROR` without a `Throwable` for a failed operation because it cannot produce the required
 non-fatal report. Do not report coroutine cancellation as a warning, error, or non-fatal.
@@ -204,9 +209,17 @@ interface PerformanceTracker {
 interface PerformanceTrace : AutoCloseable {
     operator fun set(name: String, value: Long)
     operator fun set(name: String, value: String)
-    fun setOutcome(outcome: TraceOutcome)
-    fun setPermission(permission: TracePermission)
 }
+
+inline fun <T> PerformanceTrace.measuredSection(metric: String, block: () -> T): T
+
+var PerformanceTrace.outcome: TraceOutcome
+    get() = throw UnsupportedOperationException(...)
+    set(value) { this["outcome"] = ... }
+
+var PerformanceTrace.permission: TracePermission
+    get() = throw UnsupportedOperationException(...)
+    set(value) { this["permission"] = ... }
 
 enum class TraceOutcome {
     Success,
@@ -233,8 +246,11 @@ Requirements for the adapter and contract:
 - `startCancellableTrace` starts and scopes an independent trace handle. It records the standard
   `outcome=cancelled` attribute and closes the handle when the block returns, throws, or is cancelled.
 - `trace[name] = longValue` records a metric, while `trace[name] = stringValue` records an attribute.
-- Shared values use typed setters such as `trace.setOutcome(TraceOutcome.Success)` and
-  `trace.setPermission(TracePermission.Granted)`; operation-specific attributes stay local.
+- Shared values use typed setters such as `trace.outcome = TraceOutcome.Success` and
+  `trace.permission = TracePermission.Granted`; operation-specific attributes stay local. Both are
+  write-only extension properties; reading either throws.
+- Wrap a timed step with `trace.measuredSection(metric) { ... }` instead of `measureTimedValue`; it
+  records the duration as a metric and returns the block's value.
 - Each emitting repository owns private operation-specific names that satisfy Firebase naming limits.
 - Callers record the parent outcome attribute inside the trace block before it returns or throws.
 - Instrumentation must not change repository results, cache semantics, dispatcher selection, or
@@ -291,30 +307,43 @@ does not speculate beyond these APIs or change their established result behavior
 ### `manifest_load`
 
 This trace measures the complete readable-manifest request from `ManifestParser.manifest`.
+`componentIntentFilters` (the other public method on `ManifestParser`) has exactly one caller —
+`AppDetailRepositoryImpl` — and is already fully covered by that caller's `app_detail_load` stage
+timing, so it does not own a second trace or duplicate logging of its own.
 
 | Attribute | Values |
 |---|---|
 | `outcome` | `success`, `error`, `cancelled` |
 | `analysis_mode` | `installed`, `apk_file` |
-| `split_count_bucket` | `0`, `1_4`, `5_9`, `10_plus` |
+
+`split_count_bucket` was planned here but dropped: bucketing split count only adds segmentation value
+once a production question needs it, and nothing does yet.
 
 ## Supporting Trace Design
 
 Add these traces after the three primary traces use the same infrastructure successfully:
 
-| Trace | Key attributes |
-|---|---|
-| `app_signing_index_load` | `outcome`, `trigger` |
-| `storage_stats_load` | `outcome`, `permission`, `trigger` |
-| `usage_stats_load` | `outcome`, `permission` |
-| `device_features_load` | `outcome` |
+| Trace | Key attributes | Custom metrics |
+|---|---|---|
+| `app_signing_index_load` | `outcome` | `package_query_ms`, `signing_extraction_ms` |
+| `storage_stats_load` | `outcome`, `permission`, `trigger` | `storage_stats_query_ms` |
+| `usage_stats_load` | `outcome`, `permission` | `usage_stats_query_ms` |
+| `app_index_build` | `outcome` | `app_count`, `index_build_ms` |
+| `device_features_load` | `outcome` | — (not yet instrumented; single memoized `PackageManager` call, low value) |
 
-The current enrichment entry points do not carry the installed-list trigger through their public
-repository APIs. Storage reports `trigger=installed_apps` for list-driven requests and
-`trigger=lifecycle_start` for foreground refreshes. Usage has only lifecycle-driven bulk refreshes,
-so it does not record a constant trigger attribute; its single-package query remains part of
-app-detail work. Both enrichment traces report `permission=granted|denied` and use
-`outcome=degraded` when permission is missing or a storage query yields partial data.
+`app_signing_index_load` has one reload path (package-change driven), so a `trigger` attribute would
+never vary and was dropped — it wouldn't segment anything. The current enrichment entry points do not
+carry the installed-list trigger through their public repository APIs. Storage reports
+`trigger=installed_apps` for list-driven requests and `trigger=lifecycle_start` for foreground
+refreshes. Usage has only lifecycle-driven bulk refreshes, so it does not record a constant trigger
+attribute; its single-package query remains part of app-detail work. Both enrichment traces report
+`permission=granted|denied` and use `outcome=degraded` when permission is missing or a storage query
+yields partial data.
+
+`app_index_build` (`core:app-index`) times the CPU-bound attribute-bucketing pass over the combined
+installed-app and signing-index flows — not IO-bound, but expensive enough across the full app list
+plus per-app certificates to be worth one aggregate duration metric, matching this doc's "only time
+genuinely expensive stages" rule.
 
 Do not emit one remote trace or non-fatal per installed app from bulk operations. Per-app failures
 are accumulated for logging; one non-fatal may be recorded for the operation only when the failure
@@ -339,7 +368,8 @@ cause. Add a remote custom metric only after a concrete production question just
 
 ## Rollout
 
-OBS-01 through OBS-04 are implemented. OBS-05 and later stages remain deferred.
+OBS-01 through OBS-04 are implemented. OBS-05 is partially implemented — see below. OBS-06 remains
+deferred.
 
 ### OBS-01: Make logging consistent
 
@@ -372,9 +402,16 @@ OBS-01 through OBS-04 are implemented. OBS-05 and later stages remain deferred.
 
 ### OBS-05: Instrument manifest and supporting loads
 
-- Add `manifest_load` for readable manifests.
-- Add the signing-index and device-feature traces.
-- Complete the public repository/manager load-entry inventory and document every exclusion.
+- Add `manifest_load` for readable manifests. Done.
+- Add the signing-index trace. Done — `app_signing_index_load` also fixed a latent bug where
+  `AppSigningRepositoryImpl` rethrew from a fire-and-forget `shareIn` collector with no
+  `CoroutineExceptionHandler`; it now logs and falls back to an empty index instead.
+- Add `app_index_build` (`core:app-index`) for the device-wide attribute index. Done — not in the
+  original plan, added because the grouping pass is CPU-bound over the full app list and per-app
+  certificates.
+- Add the device-feature trace. Deferred — `DeviceFeaturesRepositoryImpl` is one memoized
+  `PackageManager` call, not a loop; low value relative to the others.
+- Complete the public repository/manager load-entry inventory and document every exclusion. Deferred.
 
 ### OBS-06: Establish baselines and alerts
 

--- a/docs/technical/repository-load-performance.md
+++ b/docs/technical/repository-load-performance.md
@@ -275,6 +275,18 @@ returns a complete or degraded `AppDetail`, an error, or cancellation.
 
 An optional sub-operation that fails while `AppDetail` remains usable produces `outcome=degraded`.
 Availability attributes allow degraded requests to be filtered away from complete requests.
+The trace intentionally has no custom stage metrics: Firebase already measures the total request, and
+the existing chronological logs identify internal stages without adding permanent remote telemetry.
+
+OBS-04 uses the two availability facts persisted in `AppDetail` to classify complete versus degraded
+results: component intent filters and signing schemes. Storage size and last-used time remain nullable
+domain values that currently combine permission denial, query failure or race, and legitimate absence,
+so they cannot safely affect the parent outcome or be reconstructed on a cache hit. Likewise,
+`NativeLibraries.Empty` combines an APK with no native libraries and a handled ZIP-read failure, while
+certificate extraction exposes an empty result for both legitimate absence and handled failure.
+`ApkSigningBlockAnalyzer` returns `null` for both no detectable supported scheme and analyzer failure;
+therefore `signing_schemes=unavailable` is an availability statement, not a failure diagnosis. OBS-04
+does not speculate beyond these APIs or change their established result behavior.
 
 ### `manifest_load`
 
@@ -326,6 +338,8 @@ If a parent trace is slow, use the chronological stage logs and local profiling 
 cause. Add a remote custom metric only after a concrete production question justifies its code cost.
 
 ## Rollout
+
+OBS-01 through OBS-04 are implemented. OBS-05 and later stages remain deferred.
 
 ### OBS-01: Make logging consistent
 


### PR DESCRIPTION
## Summary
- Instrument every installed-package and APK-file detail request with one `app_detail_load` parent trace, including cache hits.
- Record bounded `analysis_mode`, `cache_hit`, `intent_filters`, `signing_schemes`, and typed terminal `outcome` attributes.
- Use `startCancellableTrace`/`use` so cancellation is propagated, cancellation outcome is owned centrally, and trace closure cannot replace the operation failure.
- Classify complete versus degraded results only from availability facts persisted in `AppDetail`, preserving cache and repository behavior.

## Follow-up: balance app-detail logging + extend to manifest, signing, and app-index loads
- Trim `app_detail_load`'s per-stage logging to DEBUG start/finish + duration via a shared `PerformanceTrace.timedSection` helper (`core:common`), with WARN only for stages that actually degrade. This replaces the flat "no custom stage metrics" approach from the original summary above — each stage now records its own `<stage>_ms` metric, not just the parent trace duration.
- Drop the now-redundant internal logging in `ManifestParser.componentIntentFilters`, since `AppDetailRepositoryImpl` (its only caller) already covers it end to end via `timedStage`.
- Add `manifest_load`, `app_signing_index_load`, and `app_index_build` traces for the previously-untimed manifest render, device-wide signing index, and browse attribute index builds (OBS-05).
- Fix a latent bug in `AppSigningRepositoryImpl` where a failure rethrown from a fire-and-forget `shareIn` collector (no `CoroutineExceptionHandler`) could crash the app or silently kill future index updates; it now logs and falls back to an empty index, matching the `InstalledAppsRepositoryImpl` fix from OBS-03.
- Restrict Crashlytics log forwarding to INFO and above (`Logger`/`FirebaseTree`, `core:common`) so the new per-stage DEBUG timing doesn't crowd out the breadcrumbs that matter by the time a crash happens.

## Follow-up: implicit PerformanceTrace receivers
- `startCancellableTrace`'s block is now `suspend PerformanceTrace.() -> T` instead of `suspend (PerformanceTrace) -> T`, so every timing/attribute call inside it (`timedSection`, `outcome`, `permission`, ...) resolves as an implicit-receiver call instead of `trace.xxx()`.
- `AppDetailRepositoryImpl`'s `installedPackageDetails`/`apkFilePackageDetails`/`getPackageDetails` become `PerformanceTrace` member extensions so the trace parameter is dropped from the whole call chain, not just the outermost block.
- Added `analysisMode` and `appCount` as write-only `PerformanceTrace` extension properties (same pattern as `outcome`/`permission`) since each now has two call sites across files. Single-call-site attributes (`intent_filters`, `signing_schemes`, `trigger`) stay as `this["key"] = value` — Kotlin's indexed-assignment operator has no implicit-receiver-only form, and a property with one caller would be pure abstraction with no reuse benefit.

## Base
Targets `develop` directly after OBS-03 merged.

## Validation
- `.\gradlew.bat spotlessApply`
- `.\gradlew.bat :core:common:compileDebugKotlin :core:common:compileReleaseKotlin :core:apps:compileDebugKotlin :core:apps:compileReleaseKotlin :core:app-index:compileDebugKotlin :app:compileDebugKotlin :app:compileReleaseKotlin`
- Verified on device (`installDebug` + driven via `adb`) for the OBS-05 tracing commit: `installed_apps_load`, `app_detail_load` (all sub-stages), `manifest_load`, `app_signing_index_load`, and `app_index_build` all fire with correct levels, messages, and real durations (e.g. signing extraction 444ms vs. package query 74ms across 620 apps); no crashes.
- The implicit-receiver refactor commit is verified by full multi-module compile only (`core:common`, `core:apps`, `core:app-index`, `app`) — it's a mechanical call-site change with no behavior difference, and the device used for the earlier on-device run had disconnected by the time this commit landed.
- `.\gradlew.bat validateAgentContext`
- `.\gradlew.bat spotlessCheck detektDebug :build-logic:convention:detektMain lintDebug :app:assembleDebug`